### PR TITLE
feat(konflate): deploy konflate 0.4.3 to render PR diffs

### DIFF
--- a/docs/superpowers/plans/2026-07-25-konflate-deployment.md
+++ b/docs/superpowers/plans/2026-07-25-konflate-deployment.md
@@ -4,7 +4,7 @@
 
 **Goal:** Deploy Konflate 0.4.3 as a public PR-diff UI for `AlinaNova21/home-ops` using GitHub App credentials for forge auth (read + write path).
 
-**Architecture:** Flux `Kustomization/konflate` (namespace `default`) renders a `HelmRelease/konflate` (chart `konflate` 0.4.3 from the shared `home-operations` OCI registry). GitHub App credentials (`appClientId`, `appSecretKey`) are synced from 1Password Connect into `Secret/konflate-github-app` and injected into the HelmRelease via two `valuesFrom` entries. Konflate is exposed on the external Gateway (Cloudflare Tunnel) at `konflate.whoverse.nexus` via a single `HTTPRoute`.
+**Architecture:** Flux `Kustomization/konflate` (namespace `default`) renders a `HelmRelease/konflate` (chart `konflate` 0.4.3 from the shared `home-operations` OCI registry). GitHub App credentials (`appClientId`, `appPrivateKey`) are synced from 1Password Connect into `Secret/konflate-github-app` and injected into the HelmRelease via two `valuesFrom` entries. Konflate is exposed on the external Gateway (Cloudflare Tunnel) at `konflate.whoverse.nexus` via a single `HTTPRoute`.
 
 **Tech Stack:** Flux CD, HelmRelease v2, External Secrets Operator, Envoy Gateway (Gateway API v1), `bjw-s`-style conventions.
 
@@ -87,10 +87,10 @@ spec:
       remoteRef:
         key: konflate-github-app
         property: appClientId
-    - secretKey: appSecretKey
+    - secretKey: appPrivateKey
       remoteRef:
         key: konflate-github-app
-        property: appSecretKey
+        property: appPrivateKey
 ```
 
 ---
@@ -139,7 +139,7 @@ spec:
       targetPath: secret.appClientId
     - kind: Secret
       name: konflate-github-app
-      valuesKey: appSecretKey
+      valuesKey: appPrivateKey
       targetPath: secret.appPrivateKey
   values:
     replicaCount: 1
@@ -304,7 +304,7 @@ Create item `konflate-github-app` in the operator's vault with two text fields:
 | Field | Value |
 |---|---|
 | `appClientId` | The GitHub App's client id (e.g. `Iv23li...`) |
-| `appSecretKey` | The PEM private key, paste with original line breaks |
+| `appPrivateKey` | The PEM private key, paste with original line breaks |
 
 - [ ] **Step 2: Confirm the App installation**
 
@@ -368,6 +368,6 @@ Open (or push to) an open PR on `AlinaNova21/home-ops`. Within
 
 **3. Type / naming consistency:**
 - HelmRelease `metadata.name: konflate`, Flux `Kustomization` `metadata.name: konflate`, ExternalSecret `metadata.name: konflate-github-app`, HTTPRoute `metadata.name: konflate`, Service target `name: konflate` (chart default from release name) — consistent.
-- `valuesFrom.valuesKey` matches `ExternalSecret.data.secretKey` (`appClientId`, `appSecretKey`) — consistent.
-- `valuesFrom.targetPath: secret.appPrivateKey` matches the chart's expected values key (the chart calls the private-key field `secret.appPrivateKey`; the operator named the 1Password field `appSecretKey`, and that label carries through ExternalSecret + Secret + HelmRelease valuesKey; only the chart-bound targetPath uses the chart's name).
+- `valuesFrom.valuesKey` matches `ExternalSecret.data.secretKey` (`appClientId`, `appPrivateKey`) — consistent.
+- `valuesFrom.targetPath: secret.appPrivateKey` matches the chart's expected values key (`secret.appPrivateKey`); all four layers (1Password field, ExternalSecret property, Secret data key, HelmRelease valuesKey) share the same `appPrivateKey` label.
 - 1Password item key matches `ExternalSecret.remoteRef.key` (`konflate-github-app`) — consistent.

--- a/docs/superpowers/plans/2026-07-25-konflate-deployment.md
+++ b/docs/superpowers/plans/2026-07-25-konflate-deployment.md
@@ -1,0 +1,373 @@
+# Konflate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Konflate 0.4.3 as a public PR-diff UI for `AlinaNova21/home-ops` using GitHub App credentials for forge auth (read + write path).
+
+**Architecture:** Flux `Kustomization/konflate` (namespace `default`) renders a `HelmRelease/konflate` (chart `konflate` 0.4.3 from the shared `home-operations` OCI registry). GitHub App credentials (`appClientId`, `appSecretKey`) are synced from 1Password Connect into `Secret/konflate-github-app` and injected into the HelmRelease via two `valuesFrom` entries. Konflate is exposed on the external Gateway (Cloudflare Tunnel) at `konflate.whoverse.nexus` via a single `HTTPRoute`.
+
+**Tech Stack:** Flux CD, HelmRelease v2, External Secrets Operator, Envoy Gateway (Gateway API v1), `bjw-s`-style conventions.
+
+---
+
+## File structure
+
+```
+kubernetes/default/konflate/
+├── ks.yaml
+└── app/
+    ├── helmrelease.yaml
+    ├── externalsecret.yaml
+    ├── httproute.yaml
+    └── kustomization.yaml
+
+kubernetes/default/kustomization.yaml     # append `konflate/ks.yaml`
+```
+
+No changes to `kubernetes/flux-config/registry/helm/*`, `kubernetes/kustomization.yaml` (top-level), `kubernetes/auth/security-policies/*`, Renovate config, or any Talos / bootstrap file.
+
+---
+
+### Task 1: Component `ks.yaml`
+
+**Files:**
+- Create: `kubernetes/default/konflate/ks.yaml`
+
+- [ ] **Step 1: Write the Flux Kustomization**
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  interval: 30m
+  path: ./default/konflate/app
+  sourceRef:
+    kind: OCIRepository
+    name: home-ops
+    namespace: flux-system
+  timeout: 10m
+  wait: true
+  prune: false
+```
+
+- [ ] **Step 2: Verify metadata.namespace matches parent directory**
+
+`metadata.namespace: default` matches `kubernetes/default/konflate/ks.yaml`. Pre-commit hook will enforce.
+
+---
+
+### Task 2: ExternalSecret for GitHub App credentials
+
+**Files:**
+- Create: `kubernetes/default/konflate/app/externalsecret.yaml`
+
+- [ ] **Step 1: Write the ExternalSecret**
+
+```yaml
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-github-app
+  namespace: default
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-github-app
+    creationPolicy: Owner
+  data:
+    - secretKey: appClientId
+      remoteRef:
+        key: konflate-github-app
+        property: appClientId
+    - secretKey: appSecretKey
+      remoteRef:
+        key: konflate-github-app
+        property: appSecretKey
+```
+
+---
+
+### Task 3: HelmRelease
+
+**Files:**
+- Create: `kubernetes/default/konflate/app/helmrelease.yaml`
+
+- [ ] **Step 1: Write the HelmRelease**
+
+```yaml
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: konflate
+      version: "0.4.3"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+      interval: 12h
+  install:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  valuesFrom:
+    - kind: Secret
+      name: konflate-github-app
+      valuesKey: appClientId
+      targetPath: secret.appClientId
+    - kind: Secret
+      name: konflate-github-app
+      valuesKey: appSecretKey
+      targetPath: secret.appPrivateKey
+  values:
+    replicaCount: 1
+    serviceAccount:
+      automount: false
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: ceph-rbd
+      accessModes:
+        - ReadWriteOnce
+    podDisruptionBudget:
+      enabled: true
+      maxUnavailable: 1
+    config:
+      repo: github://AlinaNova21/home-ops
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.whoverse.nexus
+```
+
+---
+
+### Task 4: HTTPRoute (external Gateway)
+
+**Files:**
+- Create: `kubernetes/default/konflate/app/httproute.yaml`
+
+- [ ] **Step 1: Write the HTTPRoute**
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  parentRefs:
+    - name: external
+      namespace: network
+      sectionName: http
+  hostnames:
+    - konflate.whoverse.nexus
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: konflate
+          port: 8080
+```
+
+---
+
+### Task 5: App-level kustomization
+
+**Files:**
+- Create: `kubernetes/default/konflate/app/kustomization.yaml`
+
+- [ ] **Step 1: Write the kustomization**
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - externalsecret.yaml
+  - httproute.yaml
+```
+
+---
+
+### Task 6: Wire into namespace kustomization
+
+**Files:**
+- Modify: `kubernetes/default/kustomization.yaml`
+
+- [ ] **Step 1: Append `konflate/ks.yaml`**
+
+Add a new line after the last existing component entry (after `mailpit/ks.yaml`):
+
+```yaml
+  - konflate/ks.yaml
+```
+
+Final file:
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ns.yaml
+  - barcodebuddy/ks.yaml
+  - database/ks.yaml
+  - error-pages/ks.yaml
+  - grocy/ks.yaml
+  - konflate/ks.yaml
+  - mailpit/ks.yaml
+  #- memos/ks.yaml
+  - speedtest-tracker/ks.yaml
+```
+
+(Alphabetical ordering; `konflate` between `grocy` and `mailpit`.)
+
+---
+
+### Task 7: Local validation
+
+- [ ] **Step 1: Run kustomize + kubeconform**
+
+```bash
+kustomize build kubernetes/default/konflate | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+kustomize build kubernetes | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: no schema violations, all resources listed.
+
+- [ ] **Step 2: Run pre-commit**
+
+```bash
+pre-commit run --files kubernetes/default/konflate kubernetes/default/kustomization.yaml
+```
+
+Expected: gitleaks + trufflehog pass; structure hook (ns.yaml ordering, ks.yaml metadata.namespace) passes.
+
+---
+
+### Task 8: Commit + push
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add kubernetes/default/konflate kubernetes/default/kustomization.yaml \
+        docs/superpowers/specs/2026-07-25-konflate-deployment-design.md \
+        docs/superpowers/plans/2026-07-25-konflate-deployment.md
+git commit -m "feat(konflate): deploy konflate 0.4.3 to render PR diffs"
+git push -u origin feat/konflate
+```
+
+The OCI artifact auto-builds on push to a branch (`kubernetes-oci.yml` workflow
+runs on all branches) and Flux reconciles the cluster.
+
+---
+
+### Task 9: One-time 1Password item creation (operator, manual)
+
+These are not in the repo.
+
+- [ ] **Step 1: Create the 1Password item**
+
+Create item `konflate-github-app` in the operator's vault with two text fields:
+
+| Field | Value |
+|---|---|
+| `appClientId` | The GitHub App's client id (e.g. `Iv23li...`) |
+| `appSecretKey` | The PEM private key, paste with original line breaks |
+
+- [ ] **Step 2: Confirm the App installation**
+
+GitHub → Settings → Developer settings → GitHub Apps → the App → Install App →
+`AlinaNova21/home-ops` is in the installed list.
+
+---
+
+### Task 10: Post-deploy verification
+
+- [ ] **Step 1: Force reconcile + observe**
+
+```bash
+flux reconcile kustomization cluster -n flux-system
+flux get hr -n default konflate
+kubectl get externalsecret -n default konflate-github-app
+kubectl get secret -n default konflate-github-app
+kubectl get pods -n default -l app.kubernetes.io/name=konflate
+```
+
+Expected: `HelmRelease Ready: True`, `ExternalSecret Ready: True`,
+`Secret/konflate-github-app` present, pod `Running`.
+
+- [ ] **Step 2: Public smoke test**
+
+```bash
+curl -fsS https://konflate.whoverse.nexus/api/meta | jq '.features'
+```
+
+Expected: response includes `statusChecks` and `prComments` enabled.
+
+- [ ] **Step 3: Confirm the App installation was auto-detected**
+
+```bash
+kubectl logs -n default -l app.kubernetes.io/name=konflate | grep -i 'github app'
+```
+
+Expected: log line stating the App installation id for
+`AlinaNova21/home-ops`.
+
+- [ ] **Step 4: Open or refresh a test PR; observe**
+
+Open (or push to) an open PR on `AlinaNova21/home-ops`. Within
+`KONFLATE_REFRESH_INTERVAL` (30m default) or on webhook / push:
+- A commit status `Konflate` appears on the PR head.
+- A summary comment appears on the PR (Konflate edits it in place on
+  subsequent renders).
+
+---
+
+## Self-review
+
+**1. Spec coverage:**
+- Goals (read + write, public) → Tasks 3, 9.
+- GitHub App credentials synced from 1Password → Tasks 2, 3, 9.
+- External Gateway exposure → Task 4.
+- Validation hooks (kustomize, kubeconform, pre-commit, Flux) → Task 7.
+- Post-deploy smoke tests → Task 10.
+
+**2. Placeholder scan:** no TBD/TODO; every step has concrete code.
+
+**3. Type / naming consistency:**
+- HelmRelease `metadata.name: konflate`, Flux `Kustomization` `metadata.name: konflate`, ExternalSecret `metadata.name: konflate-github-app`, HTTPRoute `metadata.name: konflate`, Service target `name: konflate` (chart default from release name) — consistent.
+- `valuesFrom.valuesKey` matches `ExternalSecret.data.secretKey` (`appClientId`, `appSecretKey`) — consistent.
+- `valuesFrom.targetPath: secret.appPrivateKey` matches the chart's expected values key (the chart calls the private-key field `secret.appPrivateKey`; the operator named the 1Password field `appSecretKey`, and that label carries through ExternalSecret + Secret + HelmRelease valuesKey; only the chart-bound targetPath uses the chart's name).
+- 1Password item key matches `ExternalSecret.remoteRef.key` (`konflate-github-app`) — consistent.

--- a/docs/superpowers/specs/2026-07-25-konflate-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-25-konflate-deployment-design.md
@@ -34,13 +34,12 @@ Service is `konflate` on port `8080` (chart default).
 
 Forge identity is a GitHub App whose client id + PEM private key are stored
 in 1Password Connect under item `konflate-github-app`, fields `appClientId`
-and `appSecretKey`, synced into the cluster by External Secrets Operator
+and `appPrivateKey`, synced into the cluster by External Secrets Operator
 into `Secret/default/konflate-github-app` (data keys `appClientId` and
-`appSecretKey`). The HelmRelease injects both via two `valuesFrom` entries:
-`appClientId` → `secret.appClientId`, and `appSecretKey` → `secret.appPrivateKey`
-(the chart's expected key name; the ExternalSecret data key keeps the operator's
-`appSecretKey` label). The App installation on `AlinaNova21/home-ops` is
-auto-discovered from `config.repo`; no installation id is configured.
+`appPrivateKey`). The HelmRelease injects both via two `valuesFrom` entries:
+`appClientId` → `secret.appClientId`, and `appPrivateKey` → `secret.appPrivateKey`.
+The App installation on `AlinaNova21/home-ops` is auto-discovered from
+`config.repo`; no installation id is configured.
 
 ## File map
 
@@ -109,7 +108,7 @@ spec:
       targetPath: secret.appClientId
     - kind: Secret
       name: konflate-github-app
-      valuesKey: appSecretKey
+      valuesKey: appPrivateKey
       targetPath: secret.appPrivateKey
   values:
     replicaCount: 1
@@ -151,10 +150,10 @@ spec:
       remoteRef:
         key: konflate-github-app
         property: appClientId
-    - secretKey: appSecretKey
+    - secretKey: appPrivateKey
       remoteRef:
         key: konflate-github-app
-        property: appSecretKey
+        property: appPrivateKey
 ```
 
 ```yaml
@@ -188,7 +187,7 @@ with two text fields:
 
 - `appClientId` — the GitHub App's **client id** (the JWT issuer; `Iv23li…`
   shape). No numeric app id needed.
-- `appSecretKey` — the PEM private key, with original line breaks preserved.
+- `appPrivateKey` — the PEM private key, with original line breaks preserved.
 
 The App must be installed on `AlinaNova21/home-ops` with these repository
 permissions:

--- a/docs/superpowers/specs/2026-07-25-konflate-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-25-konflate-deployment-design.md
@@ -1,0 +1,282 @@
+# Konflate Deployment Design
+
+> **Status:** Approved — 2026-07-25
+> **Scope:** Add Konflate 0.4.3 to `home-ops` cluster as a public-internet-facing
+> GitOps PR rendered-diff UI for `AlinaNova21/home-ops`.
+
+## Goals
+
+- Surface Flux-rendered PR diffs (blast radius, image bumps, cautions,
+  render failures) for every open PR on `AlinaNova21/home-ops`.
+- Post a Konflate commit status check + PR summary comment per render
+  (full read + write path).
+- Reachable on the external Gateway at `konflate.whoverse.nexus` (Cloudflare
+  Tunnel, public).
+
+## Non-Goals
+
+- OIDC at the edge. Konflate's HTTP surface is read-only by design; the GitHub
+  App credentials are held server-side and never read from incoming requests.
+  No `SecurityPolicy` is added.
+- Private repository reads. The repo is public; `config.repo` is the only
+  authentication boundary.
+- Custom PR filter. `KONFLATE_PR_FILTER_EXPR` left at the default `true`.
+- MCP endpoint. Off by default (`KONFLATE_MCP=false`).
+- Per-render image verification. Off by default (`KONFLATE_VERIFY_IMAGES=false`).
+
+## Architecture
+
+Single Konflate instance installed via the upstream `home-operations` OCI
+Helm chart (`oci://ghcr.io/home-operations/charts/konflate`, version `0.4.3`).
+Flux reconciles the component through a `Kustomization/konflate` rooted at
+`./default/konflate/app`. The release name is `konflate`; the resulting
+Service is `konflate` on port `8080` (chart default).
+
+Forge identity is a GitHub App whose client id + PEM private key are stored
+in 1Password Connect under item `konflate-github-app`, fields `appClientId`
+and `appSecretKey`, synced into the cluster by External Secrets Operator
+into `Secret/default/konflate-github-app` (data keys `appClientId` and
+`appSecretKey`). The HelmRelease injects both via two `valuesFrom` entries:
+`appClientId` → `secret.appClientId`, and `appSecretKey` → `secret.appPrivateKey`
+(the chart's expected key name; the ExternalSecret data key keeps the operator's
+`appSecretKey` label). The App installation on `AlinaNova21/home-ops` is
+auto-discovered from `config.repo`; no installation id is configured.
+
+## File map
+
+| Path | Purpose |
+|---|---|
+| `kubernetes/default/konflate/ks.yaml` | Flux `Kustomization/konflate` (`namespace: default`) |
+| `kubernetes/default/konflate/app/helmrelease.yaml` | `HelmRelease/konflate` (chart `konflate` 0.4.3) |
+| `kubernetes/default/konflate/app/externalsecret.yaml` | 1Password → `Secret/konflate-github-app` |
+| `kubernetes/default/konflate/app/httproute.yaml` | `HTTPRoute/konflate` on external Gateway |
+| `kubernetes/default/konflate/app/kustomization.yaml` | Aggregator for the four files above |
+| `kubernetes/default/kustomization.yaml` | Append `konflate/ks.yaml` |
+
+No changes to `kubernetes/flux-config/registry/helm/*` (existing
+`home-operations` HelmRepository already serves the chart).
+
+## Component shape
+
+```yaml
+# kubernetes/default/konflate/ks.yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  interval: 30m
+  path: ./default/konflate/app
+  sourceRef:
+    kind: OCIRepository
+    name: home-ops
+    namespace: flux-system
+  timeout: 10m
+  wait: true
+  prune: false
+```
+
+```yaml
+# kubernetes/default/konflate/app/helmrelease.yaml
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: konflate
+      version: "0.4.3"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+      interval: 12h
+  install:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  valuesFrom:
+    - kind: Secret
+      name: konflate-github-app
+      valuesKey: appClientId
+      targetPath: secret.appClientId
+    - kind: Secret
+      name: konflate-github-app
+      valuesKey: appSecretKey
+      targetPath: secret.appPrivateKey
+  values:
+    replicaCount: 1
+    serviceAccount:
+      automount: false
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: ceph-rbd
+      accessModes:
+        - ReadWriteOnce
+    podDisruptionBudget:
+      enabled: true
+      maxUnavailable: 1
+    config:
+      repo: github://AlinaNova21/home-ops
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.whoverse.nexus
+```
+
+```yaml
+# kubernetes/default/konflate/app/externalsecret.yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-github-app
+  namespace: default
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-github-app
+    creationPolicy: Owner
+  data:
+    - secretKey: appClientId
+      remoteRef:
+        key: konflate-github-app
+        property: appClientId
+    - secretKey: appSecretKey
+      remoteRef:
+        key: konflate-github-app
+        property: appSecretKey
+```
+
+```yaml
+# kubernetes/default/konflate/app/httproute.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  parentRefs:
+    - name: external
+      namespace: network
+      sectionName: http
+  hostnames:
+    - konflate.whoverse.nexus
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: konflate
+          port: 8080
+```
+
+## Identity / Forge authentication
+
+GitHub App credentials live in 1Password Connect under item `konflate-github-app`
+with two text fields:
+
+- `appClientId` — the GitHub App's **client id** (the JWT issuer; `Iv23li…`
+  shape). No numeric app id needed.
+- `appSecretKey` — the PEM private key, with original line breaks preserved.
+
+The App must be installed on `AlinaNova21/home-ops` with these repository
+permissions:
+
+| Permission | Access | Required for |
+|---|---|---|
+| Checks | Read and write | Konflate check run on PR head (falls back to commit status if absent) |
+| Pull requests | Read and write | PR summary comment, edited in place |
+| Metadata | Read-only | Repository lookup (auto-install detection) |
+
+No organization-level permissions are required. No webhook is needed
+(Konflate polls on `KONFLATE_REFRESH_INTERVAL`).
+
+## Networking
+
+- `Service/konflate` is `ClusterIP`, port `http` on `8080` (chart default).
+- `HTTPRoute/konflate` attaches to the `external` Gateway's `http` listener
+  (Cloudflare Tunnel, TLS terminated at Cloudflare). No TLS on Envoy.
+- No `NetworkPolicy` is added; Cilium default policies do not block Konflate's
+  egress (forge + git on `:443`), and Konflate does not need cluster API
+  access (chart defaults `serviceAccount.automount: false`).
+
+## Resource lifecycle
+
+- `prune: false` on the component `Kustomization` (matches the repo's
+  defensive pattern; `default/database` and `default/mailpit` both use it).
+- Helm chart default `strategy.type: Recreate` — single replica with
+  `ReadWriteOnce` PVC and in-memory state; a `RollingUpdate` would wedge
+  on Multi-Attach.
+- `PodDisruptionBudget.maxUnavailable: 1` keeps node drains unblocked
+  (single-replica chart cannot honor `minAvailable: 1`).
+
+## Security posture
+
+- Pod runs as non-root uid/gid `65532`, `runAsNonRoot: true`,
+  `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true`,
+  `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`
+  (chart defaults; verified in `values.yaml`).
+- ServiceAccount token not automounted (Konflate doesn't talk to the cluster
+  API).
+- No OIDC at the edge. Konflate's HTTP surface is read-only; the GitHub App
+  credentials live in the process and are not exposed via any inbound
+  endpoint. Status checks + comments are posted only by Konflate's own
+  render loop, never from a request.
+
+## Validation
+
+```bash
+# Local (matches CI)
+for dir in kubernetes/flux-config kubernetes; do
+  echo "=== $dir ==="
+  kustomize build "$dir" | kubeconform -strict -ignore-missing-schemas \
+    -schema-location default \
+    -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+done
+
+# After commit + push + OCI artifact builds + Flux reconciles
+flux reconcile kustomization cluster -n flux-system
+flux get hr -n default konflate
+kubectl get externalsecret -n default konflate-github-app
+kubectl get secret -n default konflate-github-app -o jsonpath='{.data.appClientId}' | base64 -d
+kubectl get pods -n default -l app.kubernetes.io/name=konflate
+
+# Public smoke test
+curl -fsS https://konflate.whoverse.nexus/api/meta | jq '.features'
+kubectl logs -n default -l app.kubernetes.io/name=konflate | grep -i 'github app'
+```
+
+Expected: `HelmRelease Ready: True`, pod `Running`, `/api/meta` returns the
+enabled write-back feature flags, the App installation is auto-detected from
+the configured repo, the first PR re-render posts a `Konflate` commit status
+and an in-place-updated summary comment on `AlinaNova21/home-ops`.
+
+## Risks (operational, not data-leak)
+
+- Anonymous external traffic fans out to GitHub App reads at the raised limit
+  (5,000 req/h vs 60 anonymous). Mitigated by per-PR coalescing +
+  `KONFLATE_REFRESH_INTERVAL=30m` + `KONFLATE_MAX_DIFF_CONC` auto-bound by
+  CPU limit.
+- If the Konflate process is compromised, the attacker can post status checks
+  + comments on `AlinaNova21/home-ops` (App's narrow scope). The same is
+  true on internal vs external exposure.
+- Persistent PVC is disposable; no protected data, no backup.
+
+## Out of scope
+
+- OIDC SecurityPolicy at the edge.
+- Prometheus ServiceMonitor (monitoring stack can opt in later if useful).
+- Backup of the persistent cache volume.
+- MCP server (`KONFLATE_MCP=false`).
+- Custom `prFilterExpr` or fork rendering.

--- a/kubernetes/default/konflate/app/externalsecret.yaml
+++ b/kubernetes/default/konflate/app/externalsecret.yaml
@@ -17,7 +17,7 @@ spec:
       remoteRef:
         key: konflate-github-app
         property: appClientId
-    - secretKey: appSecretKey
+    - secretKey: appPrivateKey
       remoteRef:
         key: konflate-github-app
-        property: appSecretKey
+        property: appPrivateKey

--- a/kubernetes/default/konflate/app/externalsecret.yaml
+++ b/kubernetes/default/konflate/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-github-app
+  namespace: default
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-github-app
+    creationPolicy: Owner
+  data:
+    - secretKey: appClientId
+      remoteRef:
+        key: konflate-github-app
+        property: appClientId
+    - secretKey: appSecretKey
+      remoteRef:
+        key: konflate-github-app
+        property: appSecretKey

--- a/kubernetes/default/konflate/app/helmrelease.yaml
+++ b/kubernetes/default/konflate/app/helmrelease.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: konflate
+      version: "0.4.3"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+      interval: 12h
+  install:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  valuesFrom:
+    - kind: Secret
+      name: konflate-github-app
+      valuesKey: appClientId
+      targetPath: secret.appClientId
+    - kind: Secret
+      name: konflate-github-app
+      valuesKey: appSecretKey
+      targetPath: secret.appPrivateKey
+  values:
+    replicaCount: 1
+    serviceAccount:
+      automount: false
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: ceph-rbd
+      accessModes:
+        - ReadWriteOnce
+    podDisruptionBudget:
+      enabled: true
+      maxUnavailable: 1
+    config:
+      repo: github://AlinaNova21/home-ops
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.whoverse.nexus

--- a/kubernetes/default/konflate/app/helmrelease.yaml
+++ b/kubernetes/default/konflate/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
       targetPath: secret.appClientId
     - kind: Secret
       name: konflate-github-app
-      valuesKey: appSecretKey
+      valuesKey: appPrivateKey
       targetPath: secret.appPrivateKey
   values:
     replicaCount: 1

--- a/kubernetes/default/konflate/app/httproute.yaml
+++ b/kubernetes/default/konflate/app/httproute.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  parentRefs:
+    - name: external
+      namespace: network
+      sectionName: http
+  hostnames:
+    - konflate.whoverse.nexus
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: konflate
+          port: 8080

--- a/kubernetes/default/konflate/app/kustomization.yaml
+++ b/kubernetes/default/konflate/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - externalsecret.yaml
+  - httproute.yaml

--- a/kubernetes/default/konflate/ks.yaml
+++ b/kubernetes/default/konflate/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: konflate
+  namespace: default
+spec:
+  interval: 30m
+  path: ./default/konflate/app
+  sourceRef:
+    kind: OCIRepository
+    name: home-ops
+    namespace: flux-system
+  timeout: 10m
+  wait: true
+  prune: false

--- a/kubernetes/default/kustomization.yaml
+++ b/kubernetes/default/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - database/ks.yaml
   - error-pages/ks.yaml
   - grocy/ks.yaml
+  - konflate/ks.yaml
   - mailpit/ks.yaml
   #- memos/ks.yaml
   - speedtest-tracker/ks.yaml


### PR DESCRIPTION
## Summary

Deploys [Konflate 0.4.3](https://github.com/home-operations/konflate) as a
public-internet-facing GitOps PR rendered-diff UI for `AlinaNova21/home-ops`.

- Reads + writes via a GitHub App (status check + summary comment per render)
- Exposed on the external Cloudflare Tunnel Gateway at `konflate.whoverse.nexus`
- 1Password Connect syncs the GitHub App credentials into `Secret/default/konflate-github-app`
- No OIDC at the edge — Konflate's HTTP surface is read-only by design

## Files

| Path | Purpose |
|---|---|
| `kubernetes/default/konflate/ks.yaml` | Flux Kustomization |
| `kubernetes/default/konflate/app/helmrelease.yaml` | HelmRelease (chart 0.4.3 from shared `home-operations` OCI) |
| `kubernetes/default/konflate/app/externalsecret.yaml` | 1Password → Secret sync |
| `kubernetes/default/konflate/app/httproute.yaml` | External Gateway route |
| `kubernetes/default/konflate/app/kustomization.yaml` | App aggregator |
| `kubernetes/default/kustomization.yaml` | Wire into namespace aggregator |

No changes to `kubernetes/flux-config/registry/helm/*` (existing
`home-operations` HelmRepository already serves the chart).

## Operator checklist (post-merge)

1. **Create the GitHub App** at https://github.com/settings/apps/new:
   - Repository permissions:
     - Checks: Read and write
     - Pull requests: Read and write
     - Metadata: Read-only (default)
   - Webhook: **inactive** (Konflate polls)
   - Install on `AlinaNova21/home-ops` only
   - Note the **Client ID** (`Iv23li…` shape) and generate a **private key**

2. **Create the 1Password item** `konflate-github-app` in the vault bound
   to `ClusterSecretStore/onepassword-connect`, with two text fields:
   - `appClientId` → the App's Client ID
   - `appPrivateKey` → the PEM private key, line breaks preserved

3. **Force reconcile:**

   ```bash
   flux reconcile kustomization cluster -n flux-system
   flux get hr -n default konflate
   ```

4. **Smoke test:**

   ```bash
   kubectl get pods -n default -l app.kubernetes.io/name=konflate
   curl -fsS https://konflate.whoverse.nexus/api/meta | jq '.features'
   ```

   Expected: `statusChecks` + `prComments` enabled in the response, first
   open PR re-renders within `KONFLATE_REFRESH_INTERVAL` (30m default) and
   posts a `Konflate` commit status + summary comment.

## Out of scope

- OIDC SecurityPolicy at the edge (Konflate's HTTP surface is read-only)
- Prometheus ServiceMonitor (opt-in later if needed)
- MCP endpoint (`KONFLATE_MCP=false`)
- Custom PR filter (default `true`)