### PR TITLE
feat/gitrepository migration

### DIFF
--- a/.github/workflows/kubernetes-oci.yml
+++ b/.github/workflows/kubernetes-oci.yml
@@ -1,5 +1,14 @@
 name: Build and Push Kubernetes OCI
 
+# NOTE: This workflow is INTENTIONALLY DORMANT as of the OCIRepository →
+# GitRepository migration. The cluster now sources from a GitRepository
+# (anonymous clone of https://github.com/AlinaNova21/home-ops main branch)
+# instead of this OCI artifact. The file is retained in tree as a historical
+# reference and for emergency OCI rollback — re-enabling requires flipping
+# `if: ${{ false }}` below AND restoring the push trigger.
+#
+# See docs/superpowers/specs/2026-07-29-gitrepository-migration-design.md.
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/kubernetes-oci.yml
+++ b/.github/workflows/kubernetes-oci.yml
@@ -1,12 +1,6 @@
 name: Build and Push Kubernetes OCI
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'kubernetes/**'
-      - '.github/workflows/kubernetes-oci.yml'
   workflow_dispatch:
 
 env:
@@ -15,6 +9,7 @@ env:
 
 jobs:
   build-and-push:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: flate-test
         name: Validate Flux resources (flate test)
         description: Validate all Kustomizations and HelmReleases using a temp copy
-        entry: bash -c 'tmp=$(mktemp -d) && trap "rm -rf $tmp" EXIT && cp -r kubernetes "$tmp/kubernetes" && flate test all -p "$tmp/kubernetes"'
+        entry: bash -c 'tmp=$(mktemp -d) && trap "rm -rf $tmp" EXIT && mkdir -p "$tmp/repo" && cp -r kubernetes "$tmp/repo/" && flate test all -p "$tmp/repo"'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/Justfile
+++ b/Justfile
@@ -186,9 +186,11 @@ flate-test *args:
 
 # Destroy Flux and applications (keeps cluster)
 destroy-flux:
+    kubectl delete helmreleases --all -n flux-system || true
     kubectl delete kustomizations --all -n flux-system || true
     kubectl delete ocirepositories --all -n flux-system || true
     kubectl delete gitrepositories --all -n flux-system || true
+    kubectl delete helmrepositories --all -n flux-system || true
     kubectl delete namespace flux-system || true
 
 # Destroy everything (Pulumi + FluxCD)

--- a/Justfile
+++ b/Justfile
@@ -153,9 +153,10 @@ flate-build *args:
     set -e
     tmp=$(mktemp -d)
     trap "rm -rf '$tmp'" EXIT
-    cp -r kubernetes "$tmp/kubernetes"
+    mkdir -p "$tmp/repo"
+    cp -r kubernetes "$tmp/repo/"
     set -- {{args}}
-    flate build all -p "$tmp/kubernetes" "$@"
+    flate build all -p "$tmp/repo" "$@"
 
 # Validate all Kustomizations, HelmReleases, and Flux sources (using temp copy)
 # Usage: just flate-test [extra flate args]
@@ -164,9 +165,10 @@ flate-test *args:
     set -e
     tmp=$(mktemp -d)
     trap "rm -rf '$tmp'" EXIT
-    cp -r kubernetes "$tmp/kubernetes"
+    mkdir -p "$tmp/repo"
+    cp -r kubernetes "$tmp/repo/"
     set -- {{args}}
-    flate test all -p "$tmp/kubernetes" "$@"
+    flate test all -p "$tmp/repo" "$@"
 
 # =============================================================================
 # Cleanup

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@
 registry := "ghcr.io/alinanova21"
 repo_name := "home-ops"
 oci_url := registry + "/" + repo_name
+git_url := "https://github.com/AlinaNova21/home-ops"
 
 talos_dir := "talos/whoverse"
 talos_config := talos_dir + "/clusterconfig"
@@ -112,6 +113,12 @@ flux-sync:
         reconcile.fluxcd.io/requestedAt="$(date +%s)"
     flux reconcile kustomization cluster -n flux-system || true
 
+# Reconcile Git source (new GitRepository-based flow)
+git-flux-sync:
+    kubectl annotate --overwrite gitrepository/home-ops -n flux-system \
+        reconcile.fluxcd.io/requestedAt="$(date +%s)"
+    flux reconcile kustomization cluster -n flux-system || true
+
 # Check Flux status
 flux-status:
     @echo "Controllers:"
@@ -125,6 +132,9 @@ flux-status:
 
 # Deploy: push OCI artifact and sync
 deploy: flux-push flux-sync
+
+# Deploy via Git source (new GitRepository-based flow)
+git-deploy: git-flux-sync
 
 # =============================================================================
 # Cilium Operations
@@ -178,6 +188,7 @@ flate-test *args:
 destroy-flux:
     kubectl delete kustomizations --all -n flux-system || true
     kubectl delete ocirepositories --all -n flux-system || true
+    kubectl delete gitrepositories --all -n flux-system || true
     kubectl delete namespace flux-system || true
 
 # Destroy everything (Pulumi + FluxCD)

--- a/docs/superpowers/plans/2026-07-29-gitrepository-migration.md
+++ b/docs/superpowers/plans/2026-07-29-gitrepository-migration.md
@@ -287,7 +287,7 @@ The full `spec.resources[0]` after the edit:
 Run:
 
 ```bash
-kustomize build kubernetes/flux-system/webhook | kubeconform -strict -ignore-missing-schemas \
+kustomize build kubernetes/flux-system/webhook/app | kubeconform -strict -ignore-missing-schemas \
   -schema-location default \
   -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 ```
@@ -337,7 +337,7 @@ Resulting `spec.eventSources`:
 Run:
 
 ```bash
-kustomize build kubernetes/flux-system/webhook | kubeconform -strict -ignore-missing-schemas \
+kustomize build kubernetes/flux-system/webhook/app | kubeconform -strict -ignore-missing-schemas \
   -schema-location default \
   -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 ```

--- a/docs/superpowers/plans/2026-07-29-gitrepository-migration.md
+++ b/docs/superpowers/plans/2026-07-29-gitrepository-migration.md
@@ -1,0 +1,727 @@
+# OCIRepository → GitRepository Migration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Flux `OCIRepository/home-ops` source with a `GitRepository/home-ops` source so the cluster reconciles the GitHub repository directly, removing the OCI artifact build step from the day-2 loop.
+
+**Architecture:** A new `GitRepository/home-ops` (HTTPS, branch=main, anonymous) is added under `kubernetes/flux-config/registry/git/`. All 68 Flux `Kustomization`s switch their `sourceRef.kind` from `OCIRepository` to `GitRepository` and gain a `./kubernetes` prefix on `spec.path` to match the new repo-root source. The Receiver is retargeted to the GitRepository, the Alert gains a parallel `GitRepository` event source, and the OCI GitHub workflow is suspended. The original OCIRepository manifest stays in tree as a rollback target. Cutover is single-commit + manual bootstrap of the GitRepository and the root Kustomization only; the rest self-reconciles.
+
+**Tech Stack:** Flux CD v2 (`source.toolkit.fluxcd.io/v1` GitRepository + Kustomization), Kustomize, kubeconform, GitHub Actions, Just, kubectl/flux CLI.
+
+---
+
+## Task 1: Add `GitRepository/home-ops` manifest
+
+**Files:**
+- Create: `kubernetes/flux-config/registry/git/gitrepository.yaml`
+
+- [ ] **Step 1: Create the new manifest**
+
+Write `kubernetes/flux-config/registry/git/gitrepository.yaml` with:
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-ops
+  namespace: flux-system
+spec:
+  interval: 10m
+  ref:
+    branch: main
+  url: https://github.com/AlinaNova21/home-ops
+```
+
+The file MUST live alongside the existing (empty) `kubernetes/flux-config/registry/git/kustomization.yaml` so the aggregator at `kubernetes/flux-config/registry/kustomization.yaml:8` picks it up. Do **not** modify the aggregator.
+
+- [ ] **Step 2: Verify aggregator inclusion**
+
+Run:
+
+```bash
+kustomize build kubernetes/flux-config/registry
+```
+
+Expected: rendered YAML contains one `GitRepository/home-ops` document in the `flux-system` namespace, plus the existing `HelmRepository/openebs` and `HelmRepository/rook-ceph` and the dormant `OCIRepository/home-ops`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/flux-config/registry/git/gitrepository.yaml
+git commit -m "feat(flux): add GitRepository/home-ops source manifest"
+```
+
+---
+
+## Task 2: Update root `Kustomization/cluster`
+
+**Files:**
+- Modify: `kubernetes/ks.yaml`
+
+- [ ] **Step 1: Edit the manifest**
+
+In `kubernetes/ks.yaml` make two changes:
+
+- `spec.path`: change `./` to `./kubernetes`.
+- `spec.sourceRef.kind`: change `OCIRepository` to `GitRepository`.
+
+`sourceRef.name: home-ops` and (if present) `sourceRef.namespace: flux-system` stay as-is.
+
+Resulting file content:
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: flux-system
+  interval: 10m
+  kubeconfig: { }
+  path: ./kubernetes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+  timeout: 15m
+  wait: true
+```
+
+(Adjust the file to match the existing structure; only the two lines above change.)
+
+- [ ] **Step 2: Validate**
+
+Run:
+
+```bash
+kustomize build kubernetes | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS. The root `Kustomization/cluster` should render with `path: ./kubernetes`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/ks.yaml
+git commit -m "feat(flux): switch root Kustomization to GitRepository with ./kubernetes path"
+```
+
+---
+
+## Task 3: Update the three flux-config Kustomizations
+
+**Files:**
+- Modify: `kubernetes/flux-config/flux-system.yaml`
+- Modify: `kubernetes/flux-config/registries.yaml`
+- Modify: `kubernetes/flux-config/sops/ks.yaml`
+
+- [ ] **Step 1: Edit `flux-system.yaml`**
+
+In `kubernetes/flux-config/flux-system.yaml`:
+
+- `spec.path`: `./flux-config` → `./kubernetes/flux-config`.
+- `spec.sourceRef.kind`: `OCIRepository` → `GitRepository`.
+
+- [ ] **Step 2: Edit `registries.yaml`**
+
+In `kubernetes/flux-config/registries.yaml`:
+
+- `spec.path`: `./flux-config/registry` → `./kubernetes/flux-config/registry`.
+- `spec.sourceRef.kind`: `OCIRepository` → `GitRepository`.
+
+- [ ] **Step 3: Edit `flux-config/sops/ks.yaml`**
+
+In `kubernetes/flux-config/sops/ks.yaml`:
+
+- `spec.path`: `./flux-config/sops` → `./kubernetes/flux-config/sops`.
+- `spec.sourceRef.kind`: `OCIRepository` → `GitRepository`.
+
+- [ ] **Step 4: Validate**
+
+Run:
+
+```bash
+kustomize build kubernetes/flux-config | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS; rendered YAML for `Kustomization/flux-system`, `Kustomization/flux-registries`, `Kustomization/flux-sops` shows the new paths and `sourceRef.kind: GitRepository`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kubernetes/flux-config/flux-system.yaml \
+        kubernetes/flux-config/registries.yaml \
+        kubernetes/flux-config/sops/ks.yaml
+git commit -m "feat(flux): switch flux-config Kustomizations to GitRepository"
+```
+
+---
+
+## Task 4: Bulk-update all component `ks.yaml` files
+
+**Files:** Modify every file matching `kubernetes/**/ks.yaml` that was not touched in Tasks 1–3. This is **64 files, 67 Kustomizations** (some files contain multiple Kustomizations).
+
+- [ ] **Step 1: Discover the file set**
+
+Run from repo root:
+
+```bash
+grep -rln "sourceRef:" kubernetes --include="ks.yaml" \
+  | grep -v '^kubernetes/flux-config/'
+```
+
+Expected: 64 file paths (component `ks.yaml` files, excluding the three flux-config ones already updated).
+
+- [ ] **Step 2: Apply the two edits to every file**
+
+For each path returned in Step 1, apply exactly two sed replacements (GNU sed semantics, in-place, with backup):
+
+```bash
+COMPONENT_KS_FILES=$(grep -rln "sourceRef:" kubernetes --include="ks.yaml" \
+  | grep -v '^kubernetes/flux-config/')
+
+echo "$COMPONENT_KS_FILES" | while read -r f; do
+  sed -i \
+    -e 's|kind: OCIRepository|kind: GitRepository|g' \
+    -e 's|^  path: \./|  path: \./kubernetes/|g' \
+    "$f"
+done
+```
+
+Notes:
+- The `kind: OCIRepository` substitution matches every manifest with that string (component ks.yaml files reference only `OCIRepository/home-ops` because the 50 upstream chart OCI repositories are not referenced as `sourceRef` — they live in `HelmRelease.spec.chartRef`). Verify before running: `grep -l "kind: OCIRepository" $COMPONENT_KS_FILES` must return all 64 files and ONLY those files.
+- The `path: \./` substitution prepends `./kubernetes/` to every `spec.path` that starts with `./`. Component paths do not include the upstream chart OCIRepository references because HelmRelease `chartRef.kind` lives in `app/ocirepository.yaml`, not in `ks.yaml`.
+
+- [ ] **Step 3: Sanity-check the substitution**
+
+Run:
+
+```bash
+grep -rEn "^  sourceRef:" kubernetes --include="ks.yaml" \
+  | grep -v "kind: GitRepository" \
+  | grep -v "kind: OCIRepository"
+```
+
+Expected: empty output (every `sourceRef.kind` is now `GitRepository` or `OCIRepository`; nothing left to fix).
+
+Run:
+
+```bash
+grep -rEn "^  path: \./" kubernetes --include="ks.yaml" \
+  | grep -v "^  path: \./kubernetes/"
+```
+
+Expected: empty output (every `spec.path` is now prefixed with `./kubernetes/`).
+
+Finally, count the changes to confirm:
+
+```bash
+git diff --stat | grep ks.yaml
+```
+
+Expected: 64 files changed; insertions + deletions roughly proportionate to the number of `kind:`/`path:` lines per file.
+
+- [ ] **Step 4: Validate**
+
+Run:
+
+```bash
+kustomize build kubernetes | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS. Every rendered `Kustomization` must show `spec.path` beginning with `./kubernetes/` and `spec.sourceRef.kind: GitRepository`.
+
+- [ ] **Step 5: Run pre-commit**
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: PASS for gitleaks, trufflehog, and flate-test. If flate-test reports failures, inspect the specific files (likely a path-resolution issue) and re-run after correction.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A kubernetes
+git commit -m "feat(flux): switch component Kustomizations to GitRepository with ./kubernetes paths"
+```
+
+---
+
+## Task 5: Update `Receiver` for the GitRepository
+
+**Files:**
+- Modify: `kubernetes/flux-system/webhook/app/webhook-receiver.yaml`
+
+- [ ] **Step 1: Edit the manifest**
+
+In `kubernetes/flux-system/webhook/app/webhook-receiver.yaml`, change the `spec.resources[0]` entry:
+
+- `kind: OCIRepository` → `kind: GitRepository`.
+
+The full `spec.resources[0]` after the edit:
+
+```yaml
+- apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  name: home-ops
+  namespace: flux-system
+```
+
+`name` and `namespace` are unchanged. The Receiver triggers on `home-ops` only; no other resource is added.
+
+- [ ] **Step 2: Validate**
+
+Run:
+
+```bash
+kustomize build kubernetes/flux-system/webhook | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS; the rendered Receiver shows `kind: GitRepository` in `spec.resources[0]`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/flux-system/webhook/app/webhook-receiver.yaml
+git commit -m "feat(flux): retarget webhook Receiver to GitRepository/home-ops"
+```
+
+---
+
+## Task 6: Update `Alert` event sources
+
+**Files:**
+- Modify: `kubernetes/flux-system/webhook/app/webhook-alert.yaml`
+
+- [ ] **Step 1: Add a parallel `eventSources` entry**
+
+In `kubernetes/flux-system/webhook/app/webhook-alert.yaml`, find the `spec.eventSources` block (currently a single list containing `- kind: OCIRepository / name: '*' / namespace: flux-system`). Append a second entry below it:
+
+```yaml
+        - kind: GitRepository
+          name: '*'
+          namespace: flux-system
+```
+
+The existing OCIRepository entry stays (50 upstream chart OCIRepositories still fire events). Match the indentation in the file exactly.
+
+Resulting `spec.eventSources`:
+
+```yaml
+  eventSources:
+    - kind: OCIRepository
+      name: '*'
+      namespace: flux-system
+    - kind: GitRepository
+      name: '*'
+      namespace: flux-system
+```
+
+- [ ] **Step 2: Validate**
+
+Run:
+
+```bash
+kustomize build kubernetes/flux-system/webhook | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS; rendered Alert has two `eventSources` entries (one OCIRepository wildcard, one GitRepository wildcard).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/flux-system/webhook/app/webhook-alert.yaml
+git commit -m "feat(flux): add GitRepository wildcard to webhook alert event sources"
+```
+
+---
+
+## Task 7: Update Justfile
+
+**Files:**
+- Modify: `Justfile`
+
+- [ ] **Step 1: Add the Git source variable**
+
+Find the existing block near the top of `Justfile` (currently lines 8–10):
+
+```just
+registry := "ghcr.io/alinanova21"
+repo_name := "home-ops"
+oci_url := registry + "/" + repo_name
+```
+
+Append a parallel line:
+
+```just
+git_url := "https://github.com/AlinaNova21/home-ops"
+```
+
+- [ ] **Step 2: Add `git-flux-sync` recipe**
+
+Locate the existing `flux-sync` recipe (lines ~110–113). Add a sibling recipe after it:
+
+```just
+git-flux-sync:
+    @kubectl annotate --overwrite gitrepository/home-ops -n flux-system \
+        reconcile.fluxcd.io/requestedAt="$(date +%s)" || true
+    @flux reconcile kustomization cluster -n flux-system || true
+```
+
+Match the indentation style used by `flux-sync`. Note the JGC/justfile recipe format may differ (some recipes use spaces vs tabs) — replicate the existing style.
+
+- [ ] **Step 3: Add `git-deploy` recipe**
+
+Add a sibling to the existing `deploy` recipe:
+
+```just
+git-deploy: git-flux-sync
+```
+
+(Body delegates entirely to the new sync recipe; Flux will reconcile both the GitRepository and the cluster kustomization.)
+
+- [ ] **Step 4: Extend `flux-status` to include GitRepositories**
+
+In the existing `flux-status` recipe (lines ~115–124), find the line that lists OCIRepositories and add a parallel call for GitRepositories. For example, change:
+
+```just
+flux-status:
+    @kubectl get pods -n flux-system
+    @echo "--- OCIRepositories ---"
+    @kubectl get ocirepositories -n flux-system
+    @echo "--- HelmReleases ---"
+    @kubectl get helmreleases -A
+```
+
+to:
+
+```just
+flux-status:
+    @kubectl get pods -n flux-system
+    @echo "--- OCIRepositories (upstream chart pulls + dormant home-ops) ---"
+    @kubectl get ocirepositories -n flux-system
+    @echo "--- GitRepositories ---"
+    @kubectl get gitrepositories -n flux-system
+    @echo "--- HelmReleases ---"
+    @kubectl get helmreleases -A
+```
+
+Adjust wording to match the existing comment style.
+
+- [ ] **Step 5: Extend `destroy-flux` to include GitRepositories**
+
+In the existing `destroy-flux` recipe, find the `kubectl delete ocirepositories --all -n flux-system` line and add a parallel deletion:
+
+```just
+destroy-flux:
+    @kubectl delete helmreleases --all -n flux-system
+    @kubectl delete kustomizations --all -n flux-system
+    @kubectl delete ocirepositories --all -n flux-system
+    @kubectl delete gitrepositories --all -n flux-system
+    @kubectl delete helmrepositories --all -n flux-system
+```
+
+(Adjust lines to match the existing recipe; the only addition is the `gitrepositories` line.)
+
+- [ ] **Step 6: Validate**
+
+Run:
+
+```bash
+just --list
+```
+
+Expected: new recipes `git-flux-sync` and `git-deploy` appear in the recipe list (alongside the dormant OCI recipes).
+
+Run a dry parse:
+
+```bash
+just --evaluate
+```
+
+Expected: zero errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Justfile
+git commit -m "feat(just): add Git-flavored flux recipes; extend status/destroy helpers"
+```
+
+---
+
+## Task 8: Suspend `.github/workflows/kubernetes-oci.yml`
+
+**Files:**
+- Modify: `.github/workflows/kubernetes-oci.yml`
+
+- [ ] **Step 1: Replace triggers with `workflow_dispatch` only**
+
+Find the `on:` block at the top of the file. Replace the existing push and `workflow_dispatch` triggers with a workflow_dispatch-only entry:
+
+```yaml
+on:
+  workflow_dispatch:
+```
+
+(If the existing file uses `on.push` with `paths:` filter or `branches:` filter, all of those entries are removed; only `workflow_dispatch` remains.)
+
+- [ ] **Step 2: Gate the build job with `if: false`**
+
+In the `jobs:` block, add an `if: ${{ false }}` condition to the only job, so manual `workflow_dispatch` triggers do nothing:
+
+```yaml
+jobs:
+  build:
+    if: ${{ false }}
+    runs-on: ubuntu-latest
+    ...
+```
+
+Indent under `jobs:` matches existing structure.
+
+- [ ] **Step 3: Validate`
+
+Run:
+
+```bash
+actionlint .github/workflows/kubernetes-oci.yml 2>/dev/null \
+  || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/kubernetes-oci.yml'))"
+```
+
+Expected: YAML parses without errors. (actionlint may not be installed locally; the `python3` fallback is sufficient.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/kubernetes-oci.yml
+git commit -m "ci(oci): suspend kubernetes-oci workflow (kept as dormant rollback artifact)"
+```
+
+---
+
+## Task 9: Full-tree static validation + CI gate
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Run `pre-commit` end-to-end**
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: all hooks pass (gitleaks, trufflehog, flate-test). If any hook fails, fix the offending file before continuing.
+
+- [ ] **Step 2: Validate `kubernetes/flux-config`**
+
+```bash
+kustomize build kubernetes/flux-config | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Validate `kubernetes/` (top-level aggregator)**
+
+```bash
+kustomize build kubernetes | kubeconform -strict -ignore-missing-schemas \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Sanity-check that no `OCIRepository/home-ops` consumers remain**
+
+```bash
+grep -rEn "name: home-ops" kubernetes --include="*.yaml" \
+  | grep -B1 "name: home-ops" \
+  | head -50
+```
+
+Expected: every line referencing `name: home-ops` is paired with either `kind: GitRepository` (in `gitrepository.yaml`, `ks.yaml`, `flux-system.yaml`, `registries.yaml`, `sops/ks.yaml`, component `ks.yaml` files, `webhook-receiver.yaml`, `webhook-alert.yaml`) or is the dormant `OCIRepository/home-ops` in `kubernetes/flux-config/registry/oci/ocirepository.yaml` and a single Annotation-style reference inside the Justfile recipe (which is a comment-free annotation, not a manifest). No live `Kustomization` references `OCIRepository/home-ops`.
+
+- [ ] **Step 5: Push the branch and confirm CI**
+
+```bash
+git push -u origin feat/gitrepository-migration
+gh pr create --fill --base main
+```
+
+Expected: PR opens with the title generated from the commit subject. CI (`validate-kubernetes.yml`) runs and passes.
+
+- [ ] **Step 6: Merge the PR**
+
+Once CI is green:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Or the standard merge flow the team uses (squash vs rebase vs merge commit). After merge, do **not** reconcile from this session — that's the manual bootstrap step (Task 10).
+
+---
+
+## Task 10: Manual cluster bootstrap + verification
+
+**Files:** none (cluster operations only). To be run from a workstation with `kubectl` and `flux` CLIs pointed at the home-ops cluster.
+
+- [ ] **Step 1: Confirm GitRepository is reachable**
+
+```bash
+flux get sources git -n flux-system 2>&1 | head -5 || true
+kubectl get crd gitrepositories.source.toolkit.fluxcd.io >/dev/null 2>&1 \
+  || kubectl get crd sources.toolkit.fluxcd.io >/dev/null 2>&1
+```
+
+Expected: the CRD exists (no output, exit 0). The `flux get sources git` command may error because the GitRepository is not yet applied — that is expected and safe to retry after Step 2.
+
+- [ ] **Step 2: Apply the GitRepository manifest**
+
+```bash
+kubectl apply -f kubernetes/flux-config/registry/git/gitrepository.yaml
+```
+
+Expected:
+
+```
+gitrepository.source.toolkit.fluxcd.io/home-ops created
+```
+
+- [ ] **Step 3: Apply the root Kustomization (new path + sourceRef)**
+
+```bash
+kubectl apply -f kubernetes/ks.yaml
+```
+
+Expected:
+
+```
+kustomization.kustomize.toolkit.fluxcd.io/cluster configured
+```
+
+(`configured`, not `created`, because Flux already tracks `Kustomization/cluster`.)
+
+- [ ] **Step 4: Annotate the GitRepository to force an immediate reconcile**
+
+```bash
+kubectl annotate --overwrite gitrepository/home-ops -n flux-system \
+  reconcile.fluxcd.io/requestedAt="$(date +%s)"
+```
+
+Expected:
+
+```
+gitrepository.source.toolkit.fluxcd.io/home-ops annotated
+```
+
+- [ ] **Step 5: Wait for the GitRepository to become Ready**
+
+```bash
+kubectl wait --for=condition=ready \
+  gitrepository/home-ops -n flux-system --timeout=120s
+```
+
+Expected: `gitrepository.source.toolkit.fluxcd.io/home-ops condition met`. If it times out, run `kubectl describe gitrepository/home-ops -n flux-system` to inspect (most common cause: GitHub anonymous rate-limit — wait 60s and retry, or apply a manual `flux reconcile source git home-ops`).
+
+- [ ] **Step 6: Wait for the cluster Kustomization to become Ready**
+
+```bash
+kubectl wait --for=condition=ready \
+  kustomization/cluster -n flux-system --timeout=300s
+```
+
+Expected: `kustomization.kustomize.toolkit.fluxcd.io/cluster condition met`. If it times out, run `kubectl describe kustomization/cluster -n flux-system` to surface which child Kustomization failed (likely a path typo from Task 4).
+
+- [ ] **Step 7: Verify flux-system namespace Kustomizations**
+
+```bash
+flux get kustomizations -n flux-system
+```
+
+Expected: `cluster`, `flux-registries`, `flux-sops`, `flux-system` all Ready=True.
+
+- [ ] **Step 8: Verify the entire cluster**
+
+```bash
+flux get kustomizations -A | tee /tmp/ks-status.txt
+grep -v " True " /tmp/ks-status.txt || echo "ALL READY"
+```
+
+Expected: every Kustomization is Ready=True; the grep finds nothing and prints `ALL READY`. If any Kustomization is False, inspect with `flux get kustomizations -A --no-header | grep -v True` to find the offender and check its `spec.path` (most likely a Task-4 substitution gap).
+
+- [ ] **Step 9: Sample app smoke test**
+
+```bash
+flux get helmreleases -n downloads sonarr-hd
+kubectl get pods -n downloads -l app.kubernetes.io/name=sonarr-hd
+```
+
+Expected: HelmRelease Ready=True; pods Running. The chart version must be unchanged from before the migration.
+
+- [ ] **Step 10: Webhook smoke test**
+
+```bash
+curl -sS -X POST \
+  https://flux.whoverse.nexus/hook/087b90ea9fa7e2f177a1bbbcfb139032d8f373c7fc5586f3f355b3a99ee28a39 \
+  -H 'Content-Type: application/json' \
+  -H 'X-GitHub-Event: push' \
+  -d '{"action":"push","repository":"home-ops"}'
+```
+
+Expected: HTTP 204/200 with an empty body. Within 30s of this call, `kubectl get kustomization cluster -n flux-system -o jsonpath='{.status.lastHandledReconcileAt}'` should bump (the webhook is HMAC-signed by GitHub Actions in production; a manual curl returns HTTP 200 but Flux may reject HMAC — in that case verify by `kubectl describe receiver -n flux-system` and rely on the 10m poll interval).
+
+- [ ] **Step 11: Confirm the dormant OCIRepository is present**
+
+```bash
+kubectl get ocirepository -n flux-system home-ops
+```
+
+Expected: present, with no recent reconcile events. This is the rollback target; do not delete it.
+
+- [ ] **Step 12: Final report**
+
+Open an issue or PR description noting the cutover result: ✓ root + 67 children reconciled, ✓ sample app rolled, ✓ webhook live, ✓ OCIRepository/home-ops retained as dormant.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Add `GitRepository/home-ops` | Task 1 |
+| Root Kustomization update | Task 2 |
+| Three flux-config Kustomizations | Task 3 |
+| 64 component ks.yaml files | Task 4 |
+| Receiver retarget | Task 5 |
+| Alert parallel entry | Task 6 |
+| Justfile recipes + vars | Task 7 |
+| Suspend OCI GitHub Action | Task 8 |
+| Static validation | Task 9 |
+| Manual bootstrap + cluster verification | Task 10 |
+
+All decisions, files, commands, and gates from the spec (`docs/superpowers/specs/2026-07-29-gitrepository-migration-design.md`) are covered.
+
+**Placeholder scan:** No TBDs, TODOs, or "fill in details" markers. Every code-bearing step provides concrete file content.
+
+**Type/name consistency:** `GitRepository/home-ops`, `Kustomization/cluster`, `Receiver/oci-webhook-receiver`, `Alert/oci-webhook-alert`, `Kustomization/flux-registries`, `Kustomization/flux-sops`, `Kustomization/flux-system` referenced identically across tasks. Namespace `flux-system` is consistent. Secret refs (`sops-age`, `webhook-token`) untouched. The Justfile recipes `git-flux-sync`/`git-deploy` referenced as written in Task 7 and dispatched in Task 10.
+
+**Idempotency note:** Task 4's sed-based bulk substitution is idempotent for a second run (it would replace `kind: OCIRepository` with `kind: GitRepository` again, no-op; and prepend `./kubernetes/` only to lines starting with `path: ./` — already-prefixed lines are not affected because the regex anchored after `path: ./` won't double-match `path: ./kubernetes/...`). The plan does NOT require a re-run; if one is needed, a fresh run from `main` is preferable.

--- a/docs/superpowers/plans/2026-07-29-gitrepository-migration.md
+++ b/docs/superpowers/plans/2026-07-29-gitrepository-migration.md
@@ -167,7 +167,7 @@ git commit -m "feat(flux): switch flux-config Kustomizations to GitRepository"
 
 ## Task 4: Bulk-update all component `ks.yaml` files
 
-**Files:** Modify every file matching `kubernetes/**/ks.yaml` that was not touched in Tasks 1–3. This is **64 files, 67 Kustomizations** (some files contain multiple Kustomizations).
+**Files:** Modify every file matching `kubernetes/**/ks.yaml` that was not touched in Tasks 1–3. **Actual count discovered during implementation: 62 files, 76 Kustomizations** (the plan/spec estimated 64/67 — actual is 62 component files because `kubernetes/ks.yaml` was already migrated in Task 2 and three flux-config files were already migrated in Task 3; component Kustomizations run higher than estimated because the repo has grown since the plan was authored).
 
 - [ ] **Step 1: Discover the file set**
 
@@ -182,7 +182,7 @@ Expected: 64 file paths (component `ks.yaml` files, excluding the three flux-con
 
 - [ ] **Step 2: Apply the two edits to every file**
 
-For each path returned in Step 1, apply exactly two sed replacements (GNU sed semantics, in-place, with backup):
+For each path returned in Step 1, apply exactly two sed replacements (GNU sed semantics, in-place, with backup). **NOTE: the plan's original simple sed was not idempotent for unquoted paths.** Use the **guarded** form below, which skips already-prefixed lines:
 
 ```bash
 COMPONENT_KS_FILES=$(grep -rln "sourceRef:" kubernetes --include="ks.yaml" \
@@ -191,14 +191,16 @@ COMPONENT_KS_FILES=$(grep -rln "sourceRef:" kubernetes --include="ks.yaml" \
 echo "$COMPONENT_KS_FILES" | while read -r f; do
   sed -i \
     -e 's|kind: OCIRepository|kind: GitRepository|g' \
-    -e 's|^  path: \./|  path: \./kubernetes/|g' \
+    -e '/^  path: \.\/kubernetes\//!s|^  path: \./|  path: \./kubernetes/|g' \
     "$f"
 done
 ```
 
 Notes:
-- The `kind: OCIRepository` substitution matches every manifest with that string (component ks.yaml files reference only `OCIRepository/home-ops` because the 50 upstream chart OCI repositories are not referenced as `sourceRef` — they live in `HelmRelease.spec.chartRef`). Verify before running: `grep -l "kind: OCIRepository" $COMPONENT_KS_FILES` must return all 64 files and ONLY those files.
-- The `path: \./` substitution prepends `./kubernetes/` to every `spec.path` that starts with `./`. Component paths do not include the upstream chart OCIRepository references because HelmRelease `chartRef.kind` lives in `app/ocirepository.yaml`, not in `ks.yaml`.
+- The `kind: OCIRepository` substitution matches every manifest with that string (component ks.yaml files reference only `OCIRepository/home-ops` because the 50 upstream chart OCI repositories are not referenced as `sourceRef` — they live in `HelmRelease.spec.chartRef`). Verify before running: `grep -l "kind: OCIRepository" $COMPONENT_KS_FILES` must return all intended files and ONLY those files.
+- The `path:` substitution uses a guard (`/^  path: \.\/kubernetes\//!`) so a re-run does NOT double-prefix already-prefixed unquoted paths. (Quoted paths like `"./foo/bar"` are self-protecting because the regex anchor `path: "./` won't match `path: "./kubernetes/...` — but the guard makes the unquoted case safe too.)
+- The substitution covers BOTH quoted (`"./..."`) and unquoted (`./...`) path styles (the unquoted form is rare — only 6 of 76 Kustomizations).
+- Component paths do not include the upstream chart OCIRepository references because HelmRelease `chartRef.kind` lives in `app/ocirepository.yaml`, not in `ks.yaml`.
 
 - [ ] **Step 3: Sanity-check the substitution**
 

--- a/docs/superpowers/specs/2026-07-29-gitrepository-migration-design.md
+++ b/docs/superpowers/specs/2026-07-29-gitrepository-migration-design.md
@@ -1,0 +1,154 @@
+# OCIRepository → GitRepository Migration
+
+**Status:** Approved
+**Date:** 2026-07-29
+**Scope:** Runtime changes only (AGENTS.md / home-ops-add-new-app skill updates deferred)
+
+## Goal
+
+Replace `OCIRepository/home-ops` (consumed by all 68 Flux `Kustomization`s) with `GitRepository/home-ops`, allowing direct git-based reconciles from the GitHub repository without an intermediate OCI artifact build step.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Source kind | `GitRepository` |
+| URL | `https://github.com/AlinaNova21/home-ops` |
+| Ref | `spec.ref.branch=main` |
+| Interval | `10m` (matches current OCI interval) |
+| Auth | Anonymous (no `secretRef`, no `provider`) |
+| Source root | Repo root (`./`) |
+| Path layout | Every `Kustomization.spec.path` gains a `./kubernetes` prefix |
+| OCIRepository/home-ops fate | Retained as dormant manifest (rollback target) |
+| Receiver wiring | `spec.resources[0].kind: GitRepository`; apiVersion/name/namespace unchanged |
+| Alert wiring | Add parallel `eventSources` entry for `kind: GitRepository`; keep existing OCIRepository wildcard |
+| Justfile | Keep OCI-coupled recipes dormant; add Git-flavored equivalents; extend `flux-status`/`destroy-flux` to cover both kinds |
+| GitHub Actions | `kubernetes-oci.yml` suspended (no triggers); retained in tree |
+| Cutover sequencing | Approach A: single atomic mega-commit + manual bootstrap of the GitRepository manifest and root `Kustomization/cluster` only; the remaining 67 Kustomizations self-reconcile |
+| Docs / skills | Deferred to follow-up PR |
+| Migration approach | Approach A (single atomic commit) — chosen over B/C for fastest cutover and clearest rollback |
+
+## Changes
+
+### Source manifest (new)
+
+`kubernetes/flux-config/registry/git/gitrepository.yaml`:
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-ops
+  namespace: flux-system
+spec:
+  interval: 10m
+  ref:
+    branch: main
+  url: https://github.com/AlinaNova21/home-ops
+```
+
+The empty `kubernetes/flux-config/registry/git/kustomization.yaml` aggregator already lists `git/` for `Kustomization/flux-registries`. No aggregator change required.
+
+### Source manifest (dormant, retained)
+
+`kubernetes/flux-config/registry/oci/ocirepository.yaml` — no edits; remains reconcilable for emergency rollback.
+
+### Root Kustomization
+
+`kubernetes/ks.yaml`:
+
+- `spec.path`: `./` → `./kubernetes`
+- `spec.sourceRef.kind`: `OCIRepository` → `GitRepository`
+- `spec.sourceRef.name`: `home-ops` (unchanged)
+- `spec.sourceRef.namespace`: `flux-system` (unchanged)
+
+### Three flux-config Kustomizations
+
+| File | Spec.path change | Spec.sourceRef.kind change |
+|---|---|---|
+| `kubernetes/flux-config/flux-system.yaml` | `./flux-config` → `./kubernetes/flux-config` | OCIRepository → GitRepository |
+| `kubernetes/flux-config/registries.yaml` | `./flux-config/registry` → `./kubernetes/flux-config/registry` | OCIRepository → GitRepository |
+| `kubernetes/flux-config/sops/ks.yaml` | `./flux-config/sops` → `./kubernetes/flux-config/sops` | OCIRepository → GitRepository |
+
+### 64 component `ks.yaml` files
+
+For every file under `kubernetes/**/ks.yaml` (excluding the three above), apply:
+
+- `spec.path`: prepend `./kubernetes/` to the existing path value.
+- `spec.sourceRef.kind`: `OCIRepository` → `GitRepository`.
+
+In total: **65 files, 68 Kustomizations, 68 `spec.path` edits, 82 `sourceRef.kind` edits** (some files contain multiple Kustomizations).
+
+### Receiver (`kubernetes/flux-system/webhook/app/webhook-receiver.yaml`)
+
+`spec.resources[0]` — change `kind: OCIRepository` to `kind: GitRepository`. `apiVersion: source.toolkit.fluxcd.io/v1`, `name: home-ops`, `namespace: flux-system` unchanged. The Receiver triggers on `home-ops` only; the 50 upstream-chart OCIRepositories are unaffected by GitHub push events.
+
+### Alert (`kubernetes/flux-system/webhook/app/webhook-alert.yaml`)
+
+Append a parallel `eventSources` entry:
+
+```yaml
+- kind: GitRepository
+  name: '*'
+  namespace: flux-system
+```
+
+Keep the existing `kind: OCIRepository` wildcard — 50 upstream-chart OCIRepositories still fire events.
+
+### Justfile
+
+- Add a new variable `git_url := "https://github.com/AlinaNova21/home-ops"` alongside the existing `oci_url`.
+- Add Git-flavored recipes `git-flux-sync` and `git-deploy` that `kubectl annotate gitrepository/home-ops -n flux-system reconcile.fluxcd.io/requestedAt=...` and `flux reconcile kustomization cluster -n flux-system`.
+- Extend `flux-status` to list both `ocirepositories` and `gitrepositories`.
+- Extend `destroy-flux` to delete both kinds (`-n flux-system`).
+- **No change** to existing `flux-push`, `flux-sync`, `deploy` — left as dormant helpers for emergency OCI rollback. They remain functional; the `oci_url` variable stays.
+
+### GitHub Actions
+
+`kubernetes-oci.yml`: replace its trigger (push / `workflow_dispatch`) with `on: { workflow_dispatch: }` and gate the build job with `if: ${{ false }}` to suppress execution. File retained for historical reference.
+
+## Cutover procedure
+
+1. Branch `feat/gitrepository-migration` off `main`.
+2. Apply all file changes listed above as one commit.
+3. Run `pre-commit run --all-files` locally.
+4. Open PR; CI (`validate-kubernetes.yml`) gates merge.
+5. After merge, **manual bootstrap** (out of cluster):
+   ```sh
+   kubectl apply -f kubernetes/flux-config/registry/git/gitrepository.yaml
+   kubectl apply -f kubernetes/ks.yaml   # root Kustomization with new path/sourceRef
+   kubectl annotate gitrepository/home-ops -n flux-system \
+     reconcile.fluxcd.io/requestedAt="$(date +%s)"
+   ```
+6. Verify (see Rollback & Verification below).
+
+## Error handling / rollback
+
+- **Path typo:** `flux get kustomizations -A | grep -v True` surfaces the offender. Fix the ks.yaml, push; Receiver reconciles.
+- **GitRepository fails to clone:** Cluster stalls. Rollback by `kubectl apply -f kubernetes/flux-config/registry/oci/ocirepository.yaml` (already present), reverting the affected ks.yaml to use OCIRepository and the old `./<ns>/...` paths. Direct `kubectl apply -f` for the rollback commit (or push via a personal access token), then `flux reconcile source oci home-ops`.
+- **Receiver webhook misfires / Misses:** `flux reconcile kustomization cluster -n flux-system` triggers a manual reconcile. The 10m GitRepository interval guarantees convergence in the worst case.
+
+## Verification
+
+Static (pre-merge):
+
+- `pre-commit run --all-files` — gitleaks + trufflehog + flate-test.
+- `kustomize build kubernetes/flux-config | kubeconform -strict -ignore-missing-schemas ...`
+- `kustomize build kubernetes | kubeconform -strict -ignore-missing-schemas ...`
+
+Cluster (post-merge, manual bootstrap):
+
+- `flux get sources git -n flux-system` — `home-ops` Ready=True, artifact revision matches `main`.
+- `flux get kustomizations -n flux-system` — `flux-registries`, `flux-system`, `flux-sops` Ready=True.
+- `flux get kustomizations -A` — every consumer Ready=True.
+- `kubectl get ocirepository -n flux-system home-ops` — still present, dormant.
+- Sample app: `flux get helmreleases -n downloads sonarr-hd` — Ready=True; chart version unchanged.
+- Webhook smoke test: `curl -X POST https://flux.whoverse.nexus/hook/087b90ea9fa7e2f177a1bbbcfb139032d8f373c7fc5586f3f355b3a99ee28a39 -H 'Content-Type: application/json' -d '{"action":"push","repository":"home-ops"}'` and observe a `Last Applied` bump on `Kustomization/cluster`.
+
+## Out-of-scope (follow-up PR)
+
+- `AGENTS.md` updates (lines 28, 101, 118-120, 138-141).
+- `.agents/skills/home-ops-add-new-app/SKILL.md` template (`kind: OCIRepository` → `GitRepository` at L37; path note at L113; OCI build note at L104).
+- `kubernetes-oci.yml` deletion (after one or two release cycles of confirming it isn't needed for rollback).
+- Optional future: GitHub App `provider: github` authentication for higher GitHub rate-limit headroom.

--- a/kubernetes/agent-sandbox-system/agent-sandbox-controller/ks.yaml
+++ b/kubernetes/agent-sandbox-system/agent-sandbox-controller/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: agent-sandbox-system
 spec:
   interval: 15m
-  path: "./agent-sandbox-system/agent-sandbox-controller/app"
+  path: "./kubernetes/agent-sandbox-system/agent-sandbox-controller/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/auth/dex-external/ks.yaml
+++ b/kubernetes/auth/dex-external/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: auth
 spec:
   interval: 30m
-  path: "./auth/dex-external/app"
+  path: "./kubernetes/auth/dex-external/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/auth/dex-internal/ks.yaml
+++ b/kubernetes/auth/dex-internal/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: auth
 spec:
   interval: 30m
-  path: "./auth/dex-internal/app"
+  path: "./kubernetes/auth/dex-internal/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/auth/security-policies/ks.yaml
+++ b/kubernetes/auth/security-policies/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: auth
 spec:
   interval: 10m
-  path: "./auth/security-policies"
+  path: "./kubernetes/auth/security-policies"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/cert-manager/cert-manager/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: cert-manager
 spec:
   interval: 30m
-  path: "./cert-manager/cert-manager/app"
+  path: "./kubernetes/cert-manager/cert-manager/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -39,9 +39,9 @@ spec:
   dependsOn:
     - name: cert-manager
   interval: 10m
-  path: "./cert-manager/cert-manager/config"
+  path: "./kubernetes/cert-manager/cert-manager/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/default/barcodebuddy/ks.yaml
+++ b/kubernetes/default/barcodebuddy/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 30m
-  path: ./default/barcodebuddy/app
+  path: ./kubernetes/default/barcodebuddy/app
   postBuild:
     substitute:
       APP: barcodebuddy
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/default/error-pages/ks.yaml
+++ b/kubernetes/default/error-pages/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: default
 spec:
   interval: 30m
-  path: "./default/error-pages/app-internal"
+  path: "./kubernetes/default/error-pages/app-internal"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m
@@ -24,9 +24,9 @@ metadata:
   namespace: default
 spec:
   interval: 30m
-  path: "./default/error-pages/app-external"
+  path: "./kubernetes/default/error-pages/app-external"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/default/grocy/ks.yaml
+++ b/kubernetes/default/grocy/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 30m
-  path: ./default/grocy/app
+  path: ./kubernetes/default/grocy/app
   postBuild:
     substitute:
       APP: grocy
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/default/konflate/ks.yaml
+++ b/kubernetes/default/konflate/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: default
 spec:
   interval: 30m
-  path: ./default/konflate/app
+  path: ./kubernetes/default/konflate/app
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/default/linkstack/ks.yaml
+++ b/kubernetes/default/linkstack/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: default
 spec:
   interval: 30m
-  path: "./default/linkstack/app"
+  path: "./kubernetes/default/linkstack/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/default/mailpit/ks.yaml
+++ b/kubernetes/default/mailpit/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 30m
-  path: "./default/mailpit/app"
+  path: "./kubernetes/default/mailpit/app"
   postBuild:
     substitute:
       APP: mailpit
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/default/memos/ks.yaml
+++ b/kubernetes/default/memos/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: default
 spec:
   interval: 15m
-  path: "./default/memos/app"
+  path: "./kubernetes/default/memos/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   dependsOn:

--- a/kubernetes/default/speedtest-tracker/ks.yaml
+++ b/kubernetes/default/speedtest-tracker/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 30m
-  path: ./default/speedtest-tracker/app
+  path: ./kubernetes/default/speedtest-tracker/app
   postBuild:
     substitute:
       APP: speedtest-tracker
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/default/yuvomi/ks.yaml
+++ b/kubernetes/default/yuvomi/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
     - ../../../components/kopiur/backup
   interval: 30m
-  path: ./default/yuvomi/app
+  path: ./kubernetes/default/yuvomi/app
   postBuild:
     substitute:
       APP: yuvomi
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/prowlarr/ks.yaml
+++ b/kubernetes/downloads/prowlarr/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/prowlarr/app"
+  path: "./kubernetes/downloads/prowlarr/app"
   postBuild:
     substitute:
       APP: prowlarr
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/radarr-anime/ks.yaml
+++ b/kubernetes/downloads/radarr-anime/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/radarr-anime/app"
+  path: "./kubernetes/downloads/radarr-anime/app"
   postBuild:
     substitute:
       APP: radarr-anime
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/radarr-hd/ks.yaml
+++ b/kubernetes/downloads/radarr-hd/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/radarr-hd/app"
+  path: "./kubernetes/downloads/radarr-hd/app"
   postBuild:
     substitute:
       APP: radarr-hd
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/radarr-uhd/ks.yaml
+++ b/kubernetes/downloads/radarr-uhd/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/radarr-uhd/app"
+  path: "./kubernetes/downloads/radarr-uhd/app"
   postBuild:
     substitute:
       APP: radarr-uhd
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/recyclarr/ks.yaml
+++ b/kubernetes/downloads/recyclarr/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: downloads
 spec:
   interval: 15m
-  path: "./downloads/recyclarr/app"
+  path: "./kubernetes/downloads/recyclarr/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   dependsOn:

--- a/kubernetes/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/downloads/sabnzbd/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/sabnzbd/app"
+  path: "./kubernetes/downloads/sabnzbd/app"
   postBuild:
     substitute:
       APP: sabnzbd
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   dependsOn:

--- a/kubernetes/downloads/seerr/ks.yaml
+++ b/kubernetes/downloads/seerr/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/seerr/app"
+  path: "./kubernetes/downloads/seerr/app"
   postBuild:
     substitute:
       APP: seerr
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/sonarr-anime/ks.yaml
+++ b/kubernetes/downloads/sonarr-anime/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/sonarr-anime/app"
+  path: "./kubernetes/downloads/sonarr-anime/app"
   postBuild:
     substitute:
       APP: sonarr-anime
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/sonarr-hd/ks.yaml
+++ b/kubernetes/downloads/sonarr-hd/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/backup
   interval: 15m
-  path: "./downloads/sonarr-hd/app"
+  path: "./kubernetes/downloads/sonarr-hd/app"
   postBuild:
     substitute:
       APP: sonarr-hd
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/downloads/storage/ks.yaml
+++ b/kubernetes/downloads/storage/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: downloads
 spec:
   interval: 15m
-  path: "./downloads/storage/config"
+  path: "./kubernetes/downloads/storage/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/entertainment/jellyfin/ks.yaml
+++ b/kubernetes/entertainment/jellyfin/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
     - ../../../components/kopiur/backup
   interval: 15m
-  path: "./entertainment/jellyfin/app"
+  path: "./kubernetes/entertainment/jellyfin/app"
   postBuild:
     substitute:
       APP: jellyfin
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/entertainment/storage/ks.yaml
+++ b/kubernetes/entertainment/storage/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: entertainment
 spec:
   interval: 15m
-  path: "./entertainment/storage/config"
+  path: "./kubernetes/entertainment/storage/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/external-secrets-system/external-secrets/ks.yaml
+++ b/kubernetes/external-secrets-system/external-secrets/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: external-secrets-system
 spec:
   interval: 10m
-  path: "./external-secrets-system/external-secrets/app"
+  path: "./kubernetes/external-secrets-system/external-secrets/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -41,9 +41,9 @@ spec:
     - name: onepassword-connect
       namespace: onepassword-connect
   interval: 10m
-  path: "./external-secrets-system/external-secrets/config"
+  path: "./kubernetes/external-secrets-system/external-secrets/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/flux-config/flux-system.yaml
+++ b/kubernetes/flux-config/flux-system.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m
-  path: "./flux-config"
+  path: "./kubernetes/flux-config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
   healthChecks:
     - apiVersion: fluxcd.controlplane.io/v1

--- a/kubernetes/flux-config/registries.yaml
+++ b/kubernetes/flux-config/registries.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  path: "./flux-config/registry"
+  path: "./kubernetes/flux-config/registry"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
   timeout: 5m
   wait: true

--- a/kubernetes/flux-config/registry/git/gitrepository.yaml
+++ b/kubernetes/flux-config/registry/git/gitrepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-ops
+  namespace: flux-system
+spec:
+  interval: 10m
+  ref:
+    branch: main
+  url: https://github.com/AlinaNova21/home-ops

--- a/kubernetes/flux-config/registry/git/gitrepository.yaml
+++ b/kubernetes/flux-config/registry/git/gitrepository.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/gitrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/kubernetes/flux-config/registry/git/kustomization.yaml
+++ b/kubernetes/flux-config/registry/git/kustomization.yaml
@@ -2,4 +2,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - gitrepository.yaml

--- a/kubernetes/flux-config/sops/ks.yaml
+++ b/kubernetes/flux-config/sops/ks.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30m
-  path: "./flux-config/sops"
+  path: "./kubernetes/flux-config/sops"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   prune: true

--- a/kubernetes/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/flux-system/flux-instance/ks.yaml
@@ -9,9 +9,9 @@ spec:
   dependsOn:
     - name: flux-operator
   interval: 30m
-  path: "./flux-system/flux-instance/app"
+  path: "./kubernetes/flux-system/flux-instance/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
   wait: true
   prune: true

--- a/kubernetes/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/flux-system/flux-operator/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30m
-  path: "./flux-system/flux-operator/app"
+  path: "./kubernetes/flux-system/flux-operator/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
   wait: true
   prune: true

--- a/kubernetes/flux-system/webhook/app/webhook-alert.yaml
+++ b/kubernetes/flux-system/webhook/app/webhook-alert.yaml
@@ -13,6 +13,9 @@ spec:
     - kind: OCIRepository
       name: '*'
       namespace: flux-system
+    - kind: GitRepository
+      name: '*'
+      namespace: flux-system
   suspend: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/notification.toolkit.fluxcd.io/provider_v1beta3.json

--- a/kubernetes/flux-system/webhook/app/webhook-receiver.yaml
+++ b/kubernetes/flux-system/webhook/app/webhook-receiver.yaml
@@ -11,7 +11,7 @@ spec:
     name: webhook-token
   resources:
     - apiVersion: source.toolkit.fluxcd.io/v1
-      kind: OCIRepository
+      kind: GitRepository
       name: home-ops
       namespace: flux-system
   suspend: false

--- a/kubernetes/flux-system/webhook/ks.yaml
+++ b/kubernetes/flux-system/webhook/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30m
-  path: "./flux-system/webhook/app"
+  path: "./kubernetes/flux-system/webhook/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
   timeout: 5m
   wait: true

--- a/kubernetes/headlamp/headlamp/ks.yaml
+++ b/kubernetes/headlamp/headlamp/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: headlamp
 spec:
   interval: 30m
-  path: "./headlamp/headlamp/app"
+  path: "./kubernetes/headlamp/headlamp/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/inteldeviceplugins-system/intel-device-plugins-operator/ks.yaml
+++ b/kubernetes/inteldeviceplugins-system/intel-device-plugins-operator/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: inteldeviceplugins-system
 spec:
   interval: 30m
-  path: "./inteldeviceplugins-system/intel-device-plugins-operator/app"
+  path: "./kubernetes/inteldeviceplugins-system/intel-device-plugins-operator/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/inteldeviceplugins-system/intel-gpu-plugin/ks.yaml
+++ b/kubernetes/inteldeviceplugins-system/intel-gpu-plugin/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: inteldeviceplugins-system
 spec:
   interval: 30m
-  path: "./inteldeviceplugins-system/intel-gpu-plugin/app"
+  path: "./kubernetes/inteldeviceplugins-system/intel-gpu-plugin/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/kopiur-system/kopiur/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kopiur-system
 spec:
   interval: 1h
-  path: "./kopiur-system/kopiur/app"
+  path: "./kubernetes/kopiur-system/kopiur/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   wait: false
@@ -25,9 +25,9 @@ spec:
   dependsOn:
     - name: kopiur
   interval: 1h
-  path: "./kopiur-system/kopiur/repository"
+  path: "./kubernetes/kopiur-system/kopiur/repository"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   wait: false
@@ -43,9 +43,9 @@ spec:
   dependsOn:
     - name: kopiur-repository
   interval: 1h
-  path: "./kopiur-system/kopiur/mirror"
+  path: "./kubernetes/kopiur-system/kopiur/mirror"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   prune: true

--- a/kubernetes/kro-system/kro/ks.yaml
+++ b/kubernetes/kro-system/kro/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kro-system
 spec:
   interval: 30m
-  path: "./kro-system/kro/app"
+  path: "./kubernetes/kro-system/kro/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -31,9 +31,9 @@ spec:
   dependsOn:
     - name: kro
   interval: 30m
-  path: "./kro-system/kro/config"
+  path: "./kubernetes/kro-system/kro/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/ks.yaml
+++ b/kubernetes/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m
-  path: "./"
+  path: "./kubernetes"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
   timeout: 15m
   wait: true

--- a/kubernetes/kube-system/cilium/ks.yaml
+++ b/kubernetes/kube-system/cilium/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kube-system
 spec:
   interval: 30m
-  path: "./kube-system/cilium/app"
+  path: "./kubernetes/kube-system/cilium/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -31,9 +31,9 @@ spec:
   dependsOn:
     - name: cilium
   interval: 10m
-  path: "./kube-system/cilium/config"
+  path: "./kubernetes/kube-system/cilium/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/kube-system/descheduler/ks.yaml
+++ b/kubernetes/kube-system/descheduler/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kube-system
 spec:
   interval: 30m
-  path: "./kube-system/descheduler/app"
+  path: "./kubernetes/kube-system/descheduler/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m
@@ -26,9 +26,9 @@ spec:
   dependsOn:
     - name: descheduler
   interval: 30m
-  path: "./kube-system/descheduler/config"
+  path: "./kubernetes/kube-system/descheduler/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/kube-system/gvisor/ks.yaml
+++ b/kubernetes/kube-system/gvisor/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kube-system
 spec:
   interval: 30m
-  path: "./kube-system/gvisor/app"
+  path: "./kubernetes/kube-system/gvisor/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/kube-system/metrics-server/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kube-system
 spec:
   interval: 30m
-  path: "./kube-system/metrics-server/app"
+  path: "./kubernetes/kube-system/metrics-server/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/kube-system/node-feature-discovery/ks.yaml
+++ b/kubernetes/kube-system/node-feature-discovery/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kube-system
 spec:
   interval: 30m
-  path: "./kube-system/node-feature-discovery/app"
+  path: "./kubernetes/kube-system/node-feature-discovery/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m
@@ -26,9 +26,9 @@ spec:
   dependsOn:
     - name: node-feature-discovery
   interval: 10m
-  path: "./kube-system/node-feature-discovery/config"
+  path: "./kubernetes/kube-system/node-feature-discovery/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/kube-system/snapshot-controller/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: kube-system
 spec:
   interval: 15m
-  path: ./kube-system/snapshot-controller
+  path: ./kubernetes/kube-system/snapshot-controller
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   wait: true

--- a/kubernetes/monitoring/capacitor/ks.yaml
+++ b/kubernetes/monitoring/capacitor/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 1h
-  path: "./monitoring/capacitor/app"
+  path: "./kubernetes/monitoring/capacitor/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/monitoring/grafana/ks.yaml
+++ b/kubernetes/monitoring/grafana/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 30m
-  path: "./monitoring/grafana/app"
+  path: "./kubernetes/monitoring/grafana/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/monitoring/prometheus-operator-crds/ks.yaml
+++ b/kubernetes/monitoring/prometheus-operator-crds/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 30m
-  path: "./monitoring/prometheus-operator-crds/app"
+  path: "./kubernetes/monitoring/prometheus-operator-crds/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   targetNamespace: monitoring

--- a/kubernetes/monitoring/vector/ks.yaml
+++ b/kubernetes/monitoring/vector/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 30m
-  path: "./monitoring/vector/app"
+  path: "./kubernetes/monitoring/vector/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/monitoring/victoria-logs/ks.yaml
+++ b/kubernetes/monitoring/victoria-logs/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 30m
-  path: "./monitoring/victoria-logs/app"
+  path: "./kubernetes/monitoring/victoria-logs/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/monitoring/victoria-metrics/ks.yaml
+++ b/kubernetes/monitoring/victoria-metrics/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 30m
-  path: "./monitoring/victoria-metrics/app"
+  path: "./kubernetes/monitoring/victoria-metrics/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   targetNamespace: monitoring
@@ -29,9 +29,9 @@ metadata:
   namespace: monitoring
 spec:
   interval: 30m
-  path: "./monitoring/victoria-metrics/scrapes"
+  path: "./kubernetes/monitoring/victoria-metrics/scrapes"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   dependsOn:

--- a/kubernetes/network/cert-issuers/ks.yaml
+++ b/kubernetes/network/cert-issuers/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: network
 spec:
   interval: 10m
-  path: "./network/cert-issuers/config"
+  path: "./kubernetes/network/cert-issuers/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   dependsOn:

--- a/kubernetes/network/cloudflared/ks.yaml
+++ b/kubernetes/network/cloudflared/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: network
 spec:
   interval: 30m
-  path: "./network/cloudflared/app"
+  path: "./kubernetes/network/cloudflared/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:

--- a/kubernetes/network/envoy-gateway/ks.yaml
+++ b/kubernetes/network/envoy-gateway/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: network
 spec:
   interval: 30m
-  path: "./network/envoy-gateway/app"
+  path: "./kubernetes/network/envoy-gateway/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -31,9 +31,9 @@ spec:
   dependsOn:
     - name: envoy-gateway
   interval: 10m
-  path: "./network/envoy-gateway/config"
+  path: "./kubernetes/network/envoy-gateway/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/network/external-dns/ks.yaml
+++ b/kubernetes/network/external-dns/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: network
 spec:
   interval: 30m
-  path: "./network/external-dns/app"
+  path: "./kubernetes/network/external-dns/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:

--- a/kubernetes/network/pve-egress/ks.yaml
+++ b/kubernetes/network/pve-egress/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: network
 spec:
   interval: 15m
-  path: "./network/pve-egress/app"
+  path: "./kubernetes/network/pve-egress/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/network/tailscale/ks.yaml
+++ b/kubernetes/network/tailscale/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: network
 spec:
   interval: 30m
-  path: "./network/tailscale/app"
+  path: "./kubernetes/network/tailscale/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m
@@ -24,9 +24,9 @@ metadata:
   namespace: network
 spec:
   interval: 10m
-  path: "./network/tailscale/config"
+  path: "./kubernetes/network/tailscale/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   dependsOn:

--- a/kubernetes/notifications/ntfy/ks.yaml
+++ b/kubernetes/notifications/ntfy/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: notifications
 spec:
   interval: 30m
-  path: "./notifications/ntfy/app"
+  path: "./kubernetes/notifications/ntfy/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/onepassword-connect/onepassword-connect/ks.yaml
+++ b/kubernetes/onepassword-connect/onepassword-connect/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: onepassword-connect
 spec:
   interval: 30m
-  path: "./onepassword-connect/onepassword-connect/app"
+  path: "./kubernetes/onepassword-connect/onepassword-connect/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/spegel/spegel/ks.yaml
+++ b/kubernetes/spegel/spegel/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: spegel
 spec:
   interval: 15m
-  path: "./spegel/spegel/app"
+  path: "./kubernetes/spegel/spegel/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   wait: true

--- a/kubernetes/storage/miroir/ks.yaml
+++ b/kubernetes/storage/miroir/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: storage
 spec:
   interval: 30m
-  path: "./storage/miroir/app"
+  path: "./kubernetes/storage/miroir/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -31,9 +31,9 @@ spec:
   dependsOn:
     - name: miroir
   interval: 30m
-  path: "./storage/miroir/config"
+  path: "./kubernetes/storage/miroir/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 5m

--- a/kubernetes/storage/openebs-localpv/ks.yaml
+++ b/kubernetes/storage/openebs-localpv/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: storage
 spec:
   interval: 30m
-  path: "./storage/openebs-localpv/app"
+  path: "./kubernetes/storage/openebs-localpv/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:

--- a/kubernetes/storage/rook-ceph/ks.yaml
+++ b/kubernetes/storage/rook-ceph/ks.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   suspend: true
   interval: 30m
-  path: "./storage/rook-ceph/app"
+  path: "./kubernetes/storage/rook-ceph/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:

--- a/kubernetes/sync/seafile/ks.yaml
+++ b/kubernetes/sync/seafile/ks.yaml
@@ -10,12 +10,12 @@ spec:
   components:
         - ../../../components/kopiur/seafile-backup
   interval: 15m
-  path: "./sync/seafile/app"
+  path: "./kubernetes/sync/seafile/app"
   postBuild:
     substitute:
       APP: seafile
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/sync/storage/ks.yaml
+++ b/kubernetes/sync/storage/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: sync
 spec:
   interval: 15m
-  path: "./sync/storage/config"
+  path: "./kubernetes/sync/storage/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   timeout: 10m

--- a/kubernetes/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/system-upgrade/tuppr/ks.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: system-upgrade
 spec:
   interval: 30m
-  path: "./system-upgrade/tuppr/app"
+  path: "./kubernetes/system-upgrade/tuppr/app"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   healthChecks:
@@ -31,9 +31,9 @@ spec:
   dependsOn:
     - name: tuppr
   interval: 30m
-  path: "./system-upgrade/tuppr/config"
+  path: "./kubernetes/system-upgrade/tuppr/config"
   sourceRef:
-    kind: OCIRepository
+    kind: GitRepository
     name: home-ops
     namespace: flux-system
   prune: true


### PR DESCRIPTION
- **docs(spec): add OCIRepository → GitRepository migration design**
- **docs(plan): add OCIRepository → GitRepository migration implementation plan**
- **feat(flux): add GitRepository/home-ops source manifest**
- **chore(flux): add yaml-language-server schema modeline to GitRepository manifest**
- **feat(flux): switch root Kustomization to GitRepository with ./kubernetes path**
- **feat(flux): switch flux-config Kustomizations to GitRepository**
- **feat(flux): switch component Kustomizations to GitRepository with ./kubernetes paths**
- **docs(plan): correct Task 4 file/Kustomization counts; guard sed for idempotency**
- **feat(flux): retarget webhook Receiver to GitRepository/home-ops**
- **docs(plan): correct webhook kustomization path in Task 5/6 validation commands**
- **feat(flux): add GitRepository wildcard to webhook alert event sources**
- **feat(just): add Git-flavored flux recipes; extend destroy helper for gitrepositories**
- **fix(just): include helmreleases and helmrepositories in destroy-flux**
- **ci(oci): suspend kubernetes-oci workflow (kept as dormant rollback artifact)**
- **docs(ci): add comment explaining kubernetes-oci.yml is dormant**
