### PR TITLE
feat(flux): modernize webhook receiver (type=github) and rename

### DIFF
--- a/kubernetes/flux-system/webhook/app/webhook-alert.yaml
+++ b/kubernetes/flux-system/webhook/app/webhook-alert.yaml
@@ -3,11 +3,11 @@
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
-  name: oci-webhook-alert
+  name: github-webhook-alert
   namespace: flux-system
 spec:
   providerRef:
-    name: oci-webhook-provider
+    name: github-webhook-provider
   eventSeverity: info
   eventSources:
     - kind: OCIRepository
@@ -22,8 +22,8 @@ spec:
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
-  name: oci-webhook-provider
+  name: github-webhook-provider
   namespace: flux-system
 spec:
   type: generic
-  address: http://notification-controller.flux-system.svc.cluster.local./receiver/oci-webhook-receiver
+  address: http://notification-controller.flux-system.svc.cluster.local./receiver/github

--- a/kubernetes/flux-system/webhook/app/webhook-receiver.yaml
+++ b/kubernetes/flux-system/webhook/app/webhook-receiver.yaml
@@ -3,10 +3,13 @@
 apiVersion: notification.toolkit.fluxcd.io/v1
 kind: Receiver
 metadata:
-  name: oci-webhook-receiver
+  name: github
   namespace: flux-system
 spec:
-  type: generic-hmac
+  type: github
+  events:
+    - "ping"
+    - "push"
   secretRef:
     name: webhook-token
   resources:


### PR DESCRIPTION
Modernizes the Flux webhook receiver to match the GitRepository/https polling architecture (OCI is now dormant per AGENTS.md).

**Changes:**
- `Receiver/oci-webhook-receiver` → `Receiver/github`
  - `type: generic-hmac` → `type: github`
  - Adds `events: [ping, push]`
  - `secretRef.name: webhook-token` unchanged
- `Alert/oci-webhook-alert` → `github-webhook-alert`
- `Provider/oci-webhook-provider` → `github-webhook-provider`
- Provider `address` updated to `/receiver/github`

**Why:**
- Per the [Flux webhook receivers guide](https://fluxcd.io/flux/guides/webhook-receivers/), `type: github` is the modern shape: it validates GitHub's `X-Hub-Signature-256` header and parses event types from the JSON payload.
- The `oci-*` prefix is misleading — the repo switched from OCI-artifact delivery to GitRepository HTTPS polling; OCI is kept dormant as rollback insurance only.
- Old resources are pruned automatically by `Kustomization/flux-webhook` (`prune: true`).

**Operational impact:**
- GitHub webhook **Payload URL will change** after this lands and Flux reconciles. The new path is deterministic from receiver name + namespace + token — it will be retrievable via `kubectl get receiver github -n flux-system`.
- GitHub webhook **Secret value does NOT change** — both `generic-hmac` and `github` use HMAC-SHA256 with the shared token; same algorithm.