### PR TITLE
docs(agents): add Agent Operating Rules section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,53 @@ Tuning:
 - gitleaks config: `.gitleaks.toml` (path-based allowlists, e.g. `charts/kasm/*.lock`)
 - Allow inline: append `# gitleaks:allow` or `# trufflehog:ignore` on the matching line
 
+## Agent Operating Rules
+
+These rules apply to every agent operating in this repo, regardless of model
+or session. They override any heuristic that would otherwise optimize for
+"just getting it done."
+
+### Explicit-orders gates
+
+The following actions require the user to give an **explicit, scoped** order
+in the current turn ("merge it", "yes, push to main", "do it"). Do **not**
+infer consent from a green CI, a passing plan, or a previous "create a PR"
+request.
+
+| Action | Why it's gated |
+|---|---|
+| `gh pr merge …` (any flag combo: `--merge`, `--squash`, `--rebase`, `--auto`, `--delete-branch`) | Merges publish to `main` and trigger Flux reconciliation cluster-wide. |
+| `git push` to `main` / `master` (including Renovate's auto-merge targets) | Direct push bypasses PR review. |
+| `git push --force` / `--force-with-lease` to any shared branch | Rewrites published history. |
+| `git reset --hard` / `git commit --amand` on a published commit | Destroys or rewrites published history. |
+| `git branch -D` on a branch that exists on `origin` | Deletes shared work. |
+| `kubectl delete` against `flux-system`, `kube-system`, `cert-manager`, `external-secrets-system`, `storage`, `network`, `monitoring`, `auth` — or any resource with `reconcile.external-secrets.io/managed=true` | Cluster state damage; some are irrecoverable without reinstall. |
+| `kubectl scale --replicas=0` or `kubectl drain` on control-plane / storage nodes | Cluster availability impact. |
+| `flux suspend …` / `flux uninstall` | Disables or removes GitOps control plane. |
+| `terraform apply` / `terraform destroy` | Infra state changes. |
+| `rm -rf` against paths outside `/tmp/opencode` | Data loss. |
+| Modifying `~/.config/opencode/`, `opencode.json`, or this repo's `.opencode/` | Changes the agent itself. |
+
+Safe without explicit orders: `git add`, `git commit` (local only), `git push`
+to a feature branch, `gh pr create` / `gh pr edit` / `gh pr comment`,
+`kubectl get` / `describe` / `logs`, `flux reconcile`, `flux resume`,
+`kustomize build`, `kubeconform`, pre-commit hooks, file edits within the
+working tree.
+
+If unsure whether an action is gated: **ask before doing it**. A two-line
+question is always cheaper than an unwanted merge.
+
+### Workflow expectations
+
+- **Stage, don't surprise.** Announce what you're about to do when the
+  action is destructive or visible (cluster-wide reconcile, secret
+  rotation, mass deletion).
+- **Verify before claiming done.** Per the project's `verification-before-completion`
+  expectation: run the check, paste the output, then assert success.
+- **Stop on user pushback.** If the user says "wait", "stop", or "did I
+  say X?", halt immediately. Summarize current state and wait for
+  direction — do not try to "fix" the situation with more changes.
+
 ## Architecture Overview
 
 - **GitOps Engine**: Flux CD with GitRepository (HTTPS, branch=main, poll interval; OCI artifact retained dormant as rollback insurance)


### PR DESCRIPTION
Codifies agent operating rules in `AGENTS.md` after a recent incident where an agent merged a PR without explicit per-turn authorization (despite a green CI run).

**What's added:**

### Explicit-orders gates
Hard rule: the following actions require the user to give an **explicit, scoped** order in the current turn. Consent must not be inferred from a green CI, a passing plan, or a previous "create a PR" request.

Gated actions:
- `gh pr merge …` (all flag combos)
- `git push` to `main` / `master` (including Renovate auto-merge targets)
- `git push --force` / `--force-with-lease` on any shared branch
- `git reset --hard` / `git commit --amend` on a published commit
- `git branch -D` on a branch that exists on `origin`
- `kubectl delete` in `flux-system`, `kube-system`, `cert-manager`, `external-secrets-system`, `storage`, `network`, `monitoring`, `auth` — or any resource with `reconcile.external-secrets.io/managed=true`
- `kubectl scale --replicas=0` / `kubectl drain` on control-plane / storage nodes
- `flux suspend …` / `flux uninstall`
- `terraform apply` / `terraform destroy`
- `rm -rf` outside `/tmp/opencode`
- Modifications to `~/.config/opencode/`, `opencode.json`, or this repo's `.opencode/`

Explicit-safe actions (do not need per-turn authorization): `git add`, `git commit` (local only), `git push` to a feature branch, `gh pr create` / `gh pr edit` / `gh pr comment`, `kubectl get` / `describe` / `logs`, `flux reconcile` / `flux resume`, `kustomize build`, `kubeconform`, pre-commit hooks, working-tree file edits.

Catch-all: when unsure — ask. A two-line question is always cheaper than an unwanted merge.

### Workflow expectations
- **Stage, don't surprise** — announce destructive/visible actions before executing.
- **Verify before claiming done** — run the check, paste the output, then assert success (per repo's `verification-before-completion` expectation).
- **Stop on user pushback** — if the user says "wait", "stop", or "did I say X?", halt immediately. Summarize state and wait. Do not try to "fix" the situation with more changes.