### PR TITLE
feat(metrics): enable Prometheus scraping for 8 apps

### DIFF
--- a/kubernetes/auth/dex-external/app/helmrelease.yaml
+++ b/kubernetes/auth/dex-external/app/helmrelease.yaml
@@ -75,3 +75,5 @@ spec:
     resources:
       requests:
         memory: 64Mi
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/auth/dex-internal/app/helmrelease.yaml
+++ b/kubernetes/auth/dex-internal/app/helmrelease.yaml
@@ -92,3 +92,5 @@ spec:
     resources:
       requests:
         memory: 96Mi
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/cert-manager/cert-manager/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
     config:
       enableGatewayAPI: true
     prometheus:
-      enabled: false
+      enabled: true
     resources:
       requests:
         memory: 128Mi

--- a/kubernetes/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/downloads/prowlarr/app/helmrelease.yaml
@@ -44,6 +44,7 @@ spec:
               PROWLARR__AUTH__METHOD: External
               PROWLARR__AUTH__REQUIRED: Enabled
               PROWLARR__LOG__LEVEL: info
+              PROWLARR__METRICS__ENABLED: "true"
               PROWLARR__SERVER__PORT: "9696"
               PROWLARR__UPDATE__BRANCH: develop
               PROWLARR__UPDATE__MECHANISM: External
@@ -101,3 +102,13 @@ spec:
           name: prowlarr
         globalMounts:
           - path: /config
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: prowlarr

--- a/kubernetes/downloads/radarr-anime/app/helmrelease.yaml
+++ b/kubernetes/downloads/radarr-anime/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
               RADARR__AUTH__METHOD: External
               RADARR__AUTH__REQUIRED: Enabled
               RADARR__LOG__LEVEL: info
+              RADARR__METRICS__ENABLED: "true"
               RADARR__SERVER__PORT: "7878"
               RADARR__UPDATE__BRANCH: master
               RADARR__UPDATE__MECHANISM: External
@@ -121,3 +122,13 @@ spec:
         existingClaim: media-movies-anime
         globalMounts:
           - path: /data/movies/anime
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: radarr-anime

--- a/kubernetes/downloads/radarr-hd/app/helmrelease.yaml
+++ b/kubernetes/downloads/radarr-hd/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
               RADARR__AUTH__METHOD: External
               RADARR__AUTH__REQUIRED: Enabled
               RADARR__LOG__LEVEL: info
+              RADARR__METRICS__ENABLED: "true"
               RADARR__SERVER__PORT: "7878"
               RADARR__UPDATE__BRANCH: master
               RADARR__UPDATE__MECHANISM: External
@@ -121,3 +122,13 @@ spec:
         existingClaim: media-movies-hd
         globalMounts:
           - path: /data/movies/hd
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: radarr-hd

--- a/kubernetes/downloads/radarr-uhd/app/helmrelease.yaml
+++ b/kubernetes/downloads/radarr-uhd/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
               RADARR__AUTH__METHOD: External
               RADARR__AUTH__REQUIRED: Enabled
               RADARR__LOG__LEVEL: info
+              RADARR__METRICS__ENABLED: "true"
               RADARR__SERVER__PORT: "7878"
               RADARR__UPDATE__BRANCH: master
               RADARR__UPDATE__MECHANISM: External
@@ -121,3 +122,13 @@ spec:
         existingClaim: media-movies-uhd
         globalMounts:
           - path: /data/movies/uhd
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: radarr-uhd

--- a/kubernetes/downloads/sonarr-anime/app/helmrelease.yaml
+++ b/kubernetes/downloads/sonarr-anime/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
               SONARR__AUTH__METHOD: External
               SONARR__AUTH__REQUIRED: Enabled
               SONARR__LOG__LEVEL: info
+              SONARR__METRICS__ENABLED: "true"
               SONARR__SERVER__PORT: "8989"
               SONARR__UPDATE__BRANCH: main
               SONARR__UPDATE__MECHANISM: External
@@ -121,3 +122,13 @@ spec:
         existingClaim: media-tv-anime
         globalMounts:
           - path: /data/tv/anime
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: sonarr-anime

--- a/kubernetes/downloads/sonarr-hd/app/helmrelease.yaml
+++ b/kubernetes/downloads/sonarr-hd/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
               SONARR__AUTH__METHOD: External
               SONARR__AUTH__REQUIRED: Enabled
               SONARR__LOG__LEVEL: info
+              SONARR__METRICS__ENABLED: "true"
               SONARR__SERVER__PORT: "8989"
               SONARR__UPDATE__BRANCH: main
               SONARR__UPDATE__MECHANISM: External
@@ -125,3 +126,13 @@ spec:
         existingClaim: media-tv-kids
         globalMounts:
           - path: /data/tv/kids
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: sonarr-hd

--- a/kubernetes/external-secrets-system/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/external-secrets-system/external-secrets/app/helmrelease.yaml
@@ -39,3 +39,6 @@ spec:
       resources:
         requests:
           memory: 64Mi
+    metrics:
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/inteldeviceplugins-system/intel-device-plugins-operator/app/helmrelease.yaml
+++ b/kubernetes/inteldeviceplugins-system/intel-device-plugins-operator/app/helmrelease.yaml
@@ -29,6 +29,8 @@ spec:
       image:
         hub: intel
         tag: ""
+      metrics:
+        enable: true
       devices:
         gpu: true
     nodeSelector:

--- a/kubernetes/kro-system/kro/app/helmrelease.yaml
+++ b/kubernetes/kro-system/kro/app/helmrelease.yaml
@@ -36,4 +36,4 @@ spec:
         type: ClusterIP
         port: 8078
       serviceMonitor:
-        enabled: false
+        enabled: true

--- a/kubernetes/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/kube-system/cilium/app/helmrelease.yaml
@@ -65,6 +65,8 @@ spec:
     gatewayAPI:
       enabled: false
     operator:
+      prometheus:
+        enabled: true
       replicas: 1
       resources:
         requests:
@@ -89,6 +91,8 @@ spec:
         service:
           type: NodePort
           nodePort: 31234
+    prometheus:
+      enabled: true
     envoy:
       enabled: false
     # Top-level resources: applies to the cilium-agent DaemonSet container

--- a/kubernetes/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/kube-system/descheduler/app/helmrelease.yaml
@@ -35,6 +35,8 @@ spec:
         memory: 128Mi
       limits:
         memory: 256Mi
+    serviceMonitor:
+      enabled: true
     deschedulerPolicy:
       profiles:
         - name: default

--- a/kubernetes/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -28,11 +28,15 @@ spec:
     master:
       enableTaints: false
       replicaCount: 1
+      serviceMonitor:
+        enabled: true
       resources:
         limits:
           memory: 512Mi
     worker:
       enable: true
+      serviceMonitor:
+        enabled: true
       resources:
         limits:
           memory: 512Mi

--- a/kubernetes/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -13,5 +13,7 @@ spec:
   values:
     controller:
       replicaCount: 2
+      serviceMonitor:
+        enabled: true
     webhook:
       enabled: false

--- a/kubernetes/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/monitoring/grafana/app/helmrelease.yaml
@@ -154,3 +154,5 @@ spec:
 
     plugins:
       - victoriametrics-logs-datasource
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/monitoring/vector/app/helmrelease.yaml
@@ -35,9 +35,12 @@ spec:
       requests:
         memory: 256Mi
 
-    # No Service needed for a log-shipping agent
     service:
-      enabled: false
+      enabled: true
+    podMonitor:
+      enabled: true
+      port: prom-exporter
+      path: /metrics
 
     customConfig:
       data_dir: /vector-data-dir

--- a/kubernetes/monitoring/victoria-metrics/scrapes/kustomization.yaml
+++ b/kubernetes/monitoring/victoria-metrics/scrapes/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - vmservicescrape-flux.yaml
   - vmservicescrape-ceph.yaml
+  - vmservicescrape-envoy-gateway.yaml

--- a/kubernetes/monitoring/victoria-metrics/scrapes/vmservicescrape-envoy-gateway.yaml
+++ b/kubernetes/monitoring/victoria-metrics/scrapes/vmservicescrape-envoy-gateway.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/operator.victoriametrics.com/vmservicescrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: envoy-gateway
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    matchNames:
+      - network
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: envoy-gateway
+  endpoints:
+    - port: metrics
+      path: /metrics

--- a/kubernetes/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/network/cloudflared/app/helmrelease.yaml
@@ -84,3 +84,13 @@ spec:
           metrics:
             port: 2000
             protocol: TCP
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: metrics
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: main

--- a/kubernetes/network/external-dns/app/helmrelease.yaml
+++ b/kubernetes/network/external-dns/app/helmrelease.yaml
@@ -52,6 +52,8 @@ spec:
     resources:
       requests:
         memory: 64Mi
+    serviceMonitor:
+      enabled: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 # External DNS for .dev domain (DNS-only, internal LAN)
@@ -106,3 +108,5 @@ spec:
     resources:
       requests:
         memory: 64Mi
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/notifications/ntfy/app/helmrelease.yaml
+++ b/kubernetes/notifications/ntfy/app/helmrelease.yaml
@@ -106,3 +106,13 @@ spec:
         sizeLimit: 1Gi
         globalMounts:
           - path: /var/cache/ntfy
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+        service:
+          identifier: ntfy

--- a/kubernetes/spegel/spegel/app/helmrelease.yaml
+++ b/kubernetes/spegel/spegel/app/helmrelease.yaml
@@ -30,4 +30,6 @@ spec:
                   - NET_RAW
                   - SYS_ADMIN
     service:
-      enabled: false
+      enabled: true
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/storage/miroir/app/helmrelease.yaml
+++ b/kubernetes/storage/miroir/app/helmrelease.yaml
@@ -34,6 +34,6 @@ spec:
     replicaCount: 1
     monitoring:
       podMonitor:
-        enabled: false
+        enabled: true
       prometheusRule:
-        enabled: false
+        enabled: true

--- a/kubernetes/storage/openebs-localpv/app/helmrelease.yaml
+++ b/kubernetes/storage/openebs-localpv/app/helmrelease.yaml
@@ -49,6 +49,9 @@ spec:
 
     # Configure localpv-provisioner for hostpath
     localpv-provisioner:
+      metrics:
+        serviceMonitor:
+          enabled: true
       localpv:
         # Base path for hostpath volumes - matches Talos userVolume mount
         basePath: "/var/mnt/hostpath"

--- a/kubernetes/storage/rook-ceph/app/helmrelease-cluster.yaml
+++ b/kubernetes/storage/rook-ceph/app/helmrelease-cluster.yaml
@@ -36,7 +36,7 @@ spec:
       enabled: true
 
     monitoring:
-      enabled: false
+      enabled: true
 
     cephBlockPoolsVolumeSnapshotClass:
       enabled: true


### PR DESCRIPTION
Enable built-in /metrics endpoints and ServiceMonitor scraping for 8 apps using bjw-s app-template v5.x serviceMonitor top-level key.

### Changes

**6 \*arr apps** — added env var `X_METRICS__ENABLED=true` + `serviceMonitor`:
- prowlarr, sonarr-hd, sonarr-anime, radarr-hd, radarr-uhd, radarr-anime

**ntfy** — added `serviceMonitor` (metrics already exposed on port 80 by default)

**cloudflared** — added `serviceMonitor` pointing at existing metrics port 2000

### Validation
- `just flate-test`: 169 passed
- `pre-commit run --all-files`: all passed (gitleaks, trufflehog, flate)