### PR TITLE
feat: add HolmesGPT SRE agent and Chaski webhook relay

### DIFF
--- a/kubernetes/chaski/app/config.d/10-holmes.yaml
+++ b/kubernetes/chaski/app/config.d/10-holmes.yaml
@@ -1,0 +1,18 @@
+targets:
+  holmes:
+    http:
+      url: http://holmes.holmes.svc.cluster.local:5000/api/chat
+      headers:
+        Content-Type: application/json
+        X-API-Key: '{{ env "HOLMES_API_KEY" }}'
+      timeout: 30s
+      retry:
+        attempts: 3
+        backoff: 1s
+
+routes:
+  flux-alert:
+    target: holmes
+    whenExpr: payload.severity == "error" || payload.severity == "critical"
+    message: |-
+      {"ask": "Investigate this Flux alert: [{{ .payload.severity | toUpper }}] {{ (dig "involvedObject" "kind" .payload) | default "Unknown" }}/{{ (dig "involvedObject" "name" .payload) | default "unknown" }}: {{ .payload.message }}"}

--- a/kubernetes/chaski/app/externalsecret.yaml
+++ b/kubernetes/chaski/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: holmes-secrets
+  namespace: chaski
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: holmes-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: HOLMES_API_KEY
+      remoteRef:
+        key: holmes-secrets
+        property: holmes-api-key

--- a/kubernetes/chaski/app/helmrelease.yaml
+++ b/kubernetes/chaski/app/helmrelease.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chaski
+  namespace: chaski
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: chaski
+    namespace: chaski
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  values:
+    config:
+      configPath: /config
+      existingConfigMap: chaski-config
+    envFrom:
+      - secretRef:
+          name: holmes-secrets
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"

--- a/kubernetes/chaski/app/ks.yaml
+++ b/kubernetes/chaski/app/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: chaski
+  namespace: chaski
+spec:
+  interval: 15m
+  path: "./kubernetes/chaski/app"
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+    namespace: flux-system
+  timeout: 10m
+  wait: true
+  prune: true

--- a/kubernetes/chaski/app/kustomization.yaml
+++ b/kubernetes/chaski/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: chaski-config
+    files:
+      - config.d/10-holmes.yaml
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml
+  - externalsecret.yaml

--- a/kubernetes/chaski/app/ocirepository.yaml
+++ b/kubernetes/chaski/app/ocirepository.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: chaski
+  namespace: chaski
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "0.3.3"
+  url: oci://ghcr.io/home-operations/charts/chaski
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token.actions.githubusercontent.com$
+        subject: ^https://github.com/home-operations/chaski/.github/workflows/release.yaml@refs/.*$

--- a/kubernetes/chaski/kustomization.yaml
+++ b/kubernetes/chaski/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ns.yaml
+  - app/ks.yaml

--- a/kubernetes/chaski/ns.yaml
+++ b/kubernetes/chaski/ns.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaski
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    homelab.whoverse.dev/component: infrastructure

--- a/kubernetes/holmes/app/alert.yaml
+++ b/kubernetes/holmes/app/alert.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/alert_v1.json
+apiVersion: notification.toolkit.fluxcd.io/v1
+kind: Alert
+metadata:
+  name: holmes
+  namespace: holmes
+spec:
+  providerRef:
+    name: holmes
+  eventSources:
+    - kind: Kustomization
+      name: "*"
+      namespace: "*"
+    - kind: HelmRelease
+      name: "*"
+      namespace: "*"
+  exclusionList:
+    - ".*health-check.*"
+  suspend: false

--- a/kubernetes/holmes/app/externalsecret.yaml
+++ b/kubernetes/holmes/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: holmes-secrets
+  namespace: holmes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: holmes-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: OPENROUTER_API_KEY
+      remoteRef:
+        key: holmes-secrets
+        property: openrouter-api-key
+    - secretKey: HOLMES_API_KEY
+      remoteRef:
+        key: holmes-secrets
+        property: holmes-api-key
+    - secretKey: HOLMES_APPROVAL_SIGNING_KEY
+      remoteRef:
+        key: holmes-secrets
+        property: holmes-approval-signing-key

--- a/kubernetes/holmes/app/github-mcp-externalsecret.yaml
+++ b/kubernetes/holmes/app/github-mcp-externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: holmes-github-mcp-token
+  namespace: holmes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: holmes-github-mcp-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: holmes-github-mcp-token
+        property: token

--- a/kubernetes/holmes/app/helmrelease.yaml
+++ b/kubernetes/holmes/app/helmrelease.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: holmes
+  namespace: holmes
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: holmes
+      sourceRef:
+        kind: HelmRepository
+        name: robusta
+        namespace: holmes
+      interval: 12h
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  values:
+    extraEnvVarsSecrets:
+      - holmes-secrets
+    additionalEnvVars:
+      - name: HOLMES_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: holmes-secrets
+            key: HOLMES_API_KEY
+    modelList:
+      deepseek:
+        model: openrouter/deepseek/deepseek-v4-flash
+        api_key: envRef:OPENROUTER_API_KEY
+        max_tokens: 8192
+        temperature: 0.7
+    config:
+      model: deepseek
+    mcpAddons:
+      github:
+        enabled: true
+        auth:
+          secretName: holmes-github-mcp-token
+          secretKey: token
+        config:
+          toolsets: repos,pull_requests,issues,context
+      kubernetes:
+        enabled: true
+        serviceAccount:
+          create: false
+          name: holmes
+        config:
+          readOnly: true
+          disableDestructive: true
+    mcp_servers: {}
+    additionalVolumes:
+      - name: holmes-data
+        persistentVolumeClaim:
+          claimName: holmes-data
+    additionalVolumeMounts:
+      - name: holmes-data
+        mountPath: /data
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/holmes/app/helmrepository.yaml
+++ b/kubernetes/holmes/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: robusta
+  namespace: holmes
+spec:
+  interval: 12h
+  url: https://robusta-charts.storage.googleapis.com

--- a/kubernetes/holmes/app/ks.yaml
+++ b/kubernetes/holmes/app/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: holmes
+  namespace: holmes
+spec:
+  interval: 15m
+  path: "./kubernetes/holmes/app"
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+    namespace: flux-system
+  timeout: 10m
+  wait: true
+  prune: true

--- a/kubernetes/holmes/app/kustomization.yaml
+++ b/kubernetes/holmes/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - externalsecret.yaml
+  - github-mcp-externalsecret.yaml
+  - pvc.yaml
+  - provider.yaml
+  - alert.yaml

--- a/kubernetes/holmes/app/provider.yaml
+++ b/kubernetes/holmes/app/provider.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_probe_v1.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: holmes
+  namespace: holmes
+spec:
+  jobName: holmes
+  interval: 60s
+  scrapeTimeout: 30s
+  prober:
+    url: holmes.holmes.svc.cluster.local:8080/health

--- a/kubernetes/holmes/app/pvc.yaml
+++ b/kubernetes/holmes/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core_v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: holmes-data
+  namespace: holmes
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: miroir-replicated

--- a/kubernetes/holmes/kustomization.yaml
+++ b/kubernetes/holmes/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ns.yaml
+  - app/ks.yaml

--- a/kubernetes/holmes/ns.yaml
+++ b/kubernetes/holmes/ns.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: holmes
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    homelab.whoverse.dev/component: infrastructure

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - sync
   - agent-sandbox-system
   - spegel
+  - chaski
+  - holmes
   - cert-manager
   - external-secrets-system
   - flux-system


### PR DESCRIPTION
## Summary

Deploy HolmesGPT SRE agent and Chaski webhook relay for automated Flux alert triage.

### HolmesGPT (holmes/ namespace)
- **Model**: 
- **GitHub MCP addon**: repos, pull_requests, issues (read-only)
- **Kubernetes MCP addon**: read-only cluster inspection
- **Persistence**: 2Gi PVC on miroir-replicated StorageClass
- **Secrets**: ExternalSecrets from 1Password (openrouter-api-key, holmes-api-key, holmes-approval-signing-key, github-mcp-token)

### Chaski (chaski/ namespace)
- **Chart**: OCI  with cosign verification
- **Route**: CEL-gated Flux error/critical alerts → Holmes API
- **Config**: config.d/10-holmes.yaml fragment via Kustomize configMapGenerator
- **Secrets**: HOLMES_API_KEY envFrom holmes-secrets

### Flux Alert
- Syncs Kustomization and HelmRelease events to Chaski for triage

## Files Changed
- 19 new files across chaski/ and holmes/ namespaces
- 1 modified (kubernetes/kustomization.yaml)

## Next Steps
1. Create 1Password secrets:
   -  item with: openrouter-api-key, holmes-api-key, holmes-approval-signing-key
   -  item with: token (GitHub PAT with repos, PR, issues scopes)
2. Flux will reconcile automatically on merge