### PR TITLE
fix: pin container images to version tags instead of latest

### DIFF
--- a/kubernetes/default/grocy/app/helmrelease.yaml
+++ b/kubernetes/default/grocy/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           grocy:
             image:
               repository: lscr.io/linuxserver/grocy
-              tag: latest@sha256:35b2c85b1238f8249c9b349fb03619d1915917e61b2e4bff580729ec87397b4c
+              tag: 4.6.0@sha256:35b2c85b1238f8249c9b349fb03619d1915917e61b2e4bff580729ec87397b4c
             env:
               TZ: America/Chicago
               GROCY_BASE_URL: https://grocy.whoverse.nexus

--- a/kubernetes/default/speedtest-tracker/app/helmrelease.yaml
+++ b/kubernetes/default/speedtest-tracker/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           speedtest-tracker:
             image:
               repository: lscr.io/linuxserver/speedtest-tracker
-              tag: latest@sha256:1647a57e0c125eac6c3a5256c499aa8f580fa7d27d0842376277cdf93e137018
+              tag: 1.14.6@sha256:1647a57e0c125eac6c3a5256c499aa8f580fa7d27d0842376277cdf93e137018
             env:
               PUID: "1000"
               PGID: "1000"

--- a/kubernetes/default/yuvomi/app/helmrelease.yaml
+++ b/kubernetes/default/yuvomi/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
           yuvomi:
             image:
               repository: ghcr.io/ulsklyc/yuvomi
-              tag: latest@sha256:3d450597ef198365dc4370d0af2ba5eb8ff1ae373d30e072d311b0d48ab0a99d
+              tag: 1.58.0@sha256:3d450597ef198365dc4370d0af2ba5eb8ff1ae373d30e072d311b0d48ab0a99d
             env:
               TZ: America/Chicago
               TRUST_PROXY: "2"

--- a/kubernetes/downloads/recyclarr/app/cronjob-radarr.yaml
+++ b/kubernetes/downloads/recyclarr/app/cronjob-radarr.yaml
@@ -20,7 +20,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: recyclarr
-              image: ghcr.io/recyclarr/recyclarr:latest@sha256:55afe316d3e4e4e3b9120cef7c79436b1b5311f6a18d4ef4b7653e720499c90a
+              image: ghcr.io/recyclarr/recyclarr:8.3.2@sha256:55afe316d3e4e4e3b9120cef7c79436b1b5311f6a18d4ef4b7653e720499c90a
               imagePullPolicy: IfNotPresent
               command:
                 - recyclarr

--- a/kubernetes/downloads/recyclarr/app/cronjob-sonarr.yaml
+++ b/kubernetes/downloads/recyclarr/app/cronjob-sonarr.yaml
@@ -20,7 +20,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: recyclarr
-              image: ghcr.io/recyclarr/recyclarr:latest@sha256:55afe316d3e4e4e3b9120cef7c79436b1b5311f6a18d4ef4b7653e720499c90a
+              image: ghcr.io/recyclarr/recyclarr:8.3.2@sha256:55afe316d3e4e4e3b9120cef7c79436b1b5311f6a18d4ef4b7653e720499c90a
               imagePullPolicy: IfNotPresent
               command:
                 - recyclarr

--- a/kubernetes/downloads/seerr/app/helmrelease.yaml
+++ b/kubernetes/downloads/seerr/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
             image:
               repository: ghcr.io/seerr-team/seerr
               # renovate: datasource=docker depName=seerr
-              tag: latest@sha256:d206d9e4056bb90178297df58047791196e7721e6dc19384579b0530702fe086
+              tag: v3.4.1@sha256:f4768de5f616248d723e05891f3345a1402123775d03bf0890dbfedc0831bda1
             env:
               TZ: "America/Chicago"
             probes:

--- a/kubernetes/notifications/ntfy/app/helmrelease.yaml
+++ b/kubernetes/notifications/ntfy/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: binwiederhier/ntfy
-              tag: latest@sha256:081b53dbb20674fcfe05fdb4eb8af9036a2645ef979543d16f7f80803af467b1
+              tag: v2.26.3@sha256:081b53dbb20674fcfe05fdb4eb8af9036a2645ef979543d16f7f80803af467b1
               pullPolicy: Always
             args:
               - serve


### PR DESCRIPTION
## Summary

Replace `:latest` tag references with explicit version tags across 6 HelmReleases/CronJobs. The digest is retained in each case to maintain immutability.

### Changes

| App | Old | New |
|-----|-----|-----|
| recyclarr (sonarr + radarr) | `latest@sha256:55afe316...` | `8.3.2@sha256:55afe316...` |
| ntfy | `latest@sha256:081b53db...` | `v2.26.3@sha256:081b53db...` |
| grocy | `latest@sha256:35b2c85b...` | `4.6.0@sha256:35b2c85b...` |
| speedtest-tracker | `latest@sha256:1647a57e...` | `1.14.6@sha256:1647a57e...` |
| yuvomi | `latest@sha256:3d450597...` | `1.58.0@sha256:3d450597...` |
| seerr | `latest@sha256:d206d9e4...` (stale) | `v3.4.1@sha256:f4768de5...` |

### Not changed (flagged for later)

- `ghcr.io/cli/cli:latest` — `kubernetes/flux-system/webhook/app/github-secret-sync-cronjob.yaml:52` — **ghcr.io auth required to resolve digest**
- `ghcr.io/kopia/kopia:latest` — `kubernetes/kopiur-system/kopiur/mirror/cronjob.yaml:22` — **ghcr.io auth required to resolve digest**
- `barcodebuddy` — no semver tag matches current `latest` digest; `v1.8.1.8` points to older image
- `linkstack` — no semver tag matches current `latest` digest; `V4` points to older image

### Verification

- `just flate-test` — ✅ 169 passed