### PR TITLE
fix(chaski): add missing namespace to kustomization.yaml

### DIFF
--- a/kubernetes/chaski/app/kustomization.yaml
+++ b/kubernetes/chaski/app/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: chaski
 configMapGenerator:
   - name: chaski-config
     files:


### PR DESCRIPTION
## Summary

The Flux Kustomization for chaski was failing with:

```
ConfigMap/chaski-config-5c4969d5gc namespace not specified: the server could not find the requested resource
```

## Root Cause

The app-level `kustomization.yaml` uses `configMapGenerator` to create `chaski-config`, but did not set `namespace: chaski`. The generated ConfigMap YAML had no `metadata.namespace`. With Flux Kustomization `spec.wait: true`, the controller could not find the ConfigMap after creation to verify it was healthy.

## Fix

Added `namespace: chaski` to `kubernetes/chaski/app/kustomization.yaml`.

## Testing

- `just flate-test` passes (182 tests)
- `pre-commit run --all-files` passes