### PR TITLE
fix(monitoring/vector): add required service ports to HelmRelease values

### DIFF
--- a/kubernetes/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/monitoring/vector/app/helmrelease.yaml
@@ -37,6 +37,11 @@ spec:
 
     service:
       enabled: true
+      ports:
+        - name: prom-exporter
+          port: 8686
+          protocol: TCP
+          targetPort: 8686
     podMonitor:
       enabled: true
       port: prom-exporter


### PR DESCRIPTION
## What

Adds  to the vector HelmRelease values.

## Why

The vector Helm chart v0.57.0 defaults  to an empty list . With  but no ports defined, the rendered  object has empty , which Kubernetes rejects:

```
Service "vector" is invalid: spec.ports: Required value
```

The DaemonSet is running fine (5/5 ready), but Helm upgrades keep failing because the chart can't reconcile the Service.

Adds the  port (8686) that the existing  already targets.

## Testing

- [x] 
  ✓  Kustomization   agent-sandbox-system/agent-sandbox-controller
  ✓  Kustomization   agent-sandbox-system/agent-sandbox-crds
  ✓  Kustomization   agent-sandbox-system/agent-sandbox-crds-source
  ✓  Kustomization   auth/dex-external
  ✓  Kustomization   auth/dex-internal
  ✓  Kustomization   auth/dex-security-policies
  ✓  Kustomization   cert-manager/cert-manager
  ✓  Kustomization   cert-manager/cert-manager-config
  ✓  Kustomization   chaski/chaski
  ✓  Kustomization   default/barcodebuddy
  ✓  Kustomization   default/error-pages-external
  ✓  Kustomization   default/error-pages-internal
  ✓  Kustomization   default/grocy
  ✓  Kustomization   default/konflate
  ✓  Kustomization   default/linkstack
  ✓  Kustomization   default/mailpit
  ✓  Kustomization   default/speedtest-tracker
  ✓  Kustomization   default/yuvomi
  ✓  Kustomization   downloads/downloads-storage
  ✓  Kustomization   downloads/prowlarr
  ✓  Kustomization   downloads/radarr-anime
  ✓  Kustomization   downloads/radarr-hd
  ✓  Kustomization   downloads/radarr-uhd
  ✓  Kustomization   downloads/recyclarr
  ✓  Kustomization   downloads/sabnzbd
  ✓  Kustomization   downloads/seerr
  ✓  Kustomization   downloads/sonarr-anime
  ✓  Kustomization   downloads/sonarr-hd
  ✓  Kustomization   entertainment/entertainment-storage
  ✓  Kustomization   entertainment/jellyfin
  ✓  Kustomization   external-secrets-system/external-secrets
  ✓  Kustomization   external-secrets-system/external-secrets-config
  ✓  Kustomization   flux-system/cluster
  ✓  Kustomization   flux-system/flux-instance
  ✓  Kustomization   flux-system/flux-operator
  ✓  Kustomization   flux-system/flux-webhook
  ✓  Kustomization   headlamp/headlamp
  ✓  Kustomization   holmes/holmes
  ✓  Kustomization   inteldeviceplugins-system/intel-device-plugins-operator
  ✓  Kustomization   inteldeviceplugins-system/intel-gpu-plugin
  ✓  Kustomization   kopiur-system/kopiur
  ✓  Kustomization   kopiur-system/kopiur-mirror
  ✓  Kustomization   kopiur-system/kopiur-repository
  ✓  Kustomization   kro-system/kro
  ✓  Kustomization   kro-system/kro-config
  ✓  Kustomization   kube-system/cilium
  ✓  Kustomization   kube-system/cilium-config
  ✓  Kustomization   kube-system/descheduler
  ✓  Kustomization   kube-system/descheduler-config
  ✓  Kustomization   kube-system/gvisor
  ✓  Kustomization   kube-system/metrics-server
  ✓  Kustomization   kube-system/node-feature-discovery
  ✓  Kustomization   kube-system/node-feature-discovery-config
  ✓  Kustomization   kube-system/snapshot-controller
  ✓  Kustomization   monitoring/capacitor
  ✓  Kustomization   monitoring/capacitor-config
  ✓  Kustomization   monitoring/grafana
  ✓  Kustomization   monitoring/prometheus-operator-crds
  ✓  Kustomization   monitoring/vector
  ✓  Kustomization   monitoring/victoria-logs
  ✓  Kustomization   monitoring/victoria-metrics
  ✓  Kustomization   monitoring/victoria-metrics-scrapes
  ✓  Kustomization   network/cert-issuers
  ✓  Kustomization   network/cloudflared
  ✓  Kustomization   network/envoy-gateway
  ✓  Kustomization   network/envoy-gateway-config
  ✓  Kustomization   network/external-dns
  ✓  Kustomization   network/pve-egress
  ✓  Kustomization   network/tailscale-operator
  ✓  Kustomization   network/tailscale-operator-config
  ✓  Kustomization   notifications/ntfy
  ✓  Kustomization   onepassword-connect/onepassword-connect
  ✓  Kustomization   spegel/spegel
  ✓  Kustomization   storage/miroir
  ✓  Kustomization   storage/miroir-config
  ✓  Kustomization   system-upgrade/tuppr
  ✓  Kustomization   system-upgrade/tuppr-config
  ✓  HelmRelease     agent-sandbox-system/agent-sandbox-controller
  ✓  HelmRelease     auth/dex-external
  ✓  HelmRelease     auth/dex-internal
  ✓  HelmRelease     cert-manager/cert-manager
  ✓  HelmRelease     chaski/chaski
  ✓  HelmRelease     default/barcodebuddy
  ✓  HelmRelease     default/error-pages-external
  ✓  HelmRelease     default/error-pages-internal
  ✓  HelmRelease     default/grocy
  ✓  HelmRelease     default/konflate
  ✓  HelmRelease     default/linkstack
  ✓  HelmRelease     default/mailpit
  ✓  HelmRelease     default/speedtest-tracker
  ✓  HelmRelease     default/yuvomi
  ✓  HelmRelease     downloads/prowlarr
  ✓  HelmRelease     downloads/radarr-anime
  ✓  HelmRelease     downloads/radarr-hd
  ✓  HelmRelease     downloads/radarr-uhd
  ✓  HelmRelease     downloads/sabnzbd
  ✓  HelmRelease     downloads/seerr
  ✓  HelmRelease     downloads/sonarr-anime
  ✓  HelmRelease     downloads/sonarr-hd
  ✓  HelmRelease     entertainment/jellyfin
  ✓  HelmRelease     external-secrets-system/external-secrets
  ✓  HelmRelease     flux-system/flux-operator
  ✓  HelmRelease     headlamp/headlamp
  ✓  HelmRelease     holmes/holmes
  ✓  HelmRelease     inteldeviceplugins-system/intel-device-plugins-operator
  ✓  HelmRelease     inteldeviceplugins-system/intel-gpu-plugin
  ✓  HelmRelease     kopiur-system/kopiur
  ✓  HelmRelease     kro-system/kro
  ✓  HelmRelease     kube-system/cilium
  ✓  HelmRelease     kube-system/descheduler
  ✓  HelmRelease     kube-system/metrics-server
  ✓  HelmRelease     kube-system/node-feature-discovery
  ✓  HelmRelease     kube-system/snapshot-controller
  ✓  HelmRelease     monitoring/grafana
  ✓  HelmRelease     monitoring/prometheus-operator-crds
  ✓  HelmRelease     monitoring/vector
  ✓  HelmRelease     monitoring/victoria-logs
  ✓  HelmRelease     monitoring/victoria-metrics
  ✓  HelmRelease     network/cloudflared
  ✓  HelmRelease     network/envoy-gateway
  ✓  HelmRelease     network/external-dns-dev
  ✓  HelmRelease     network/external-dns-nexus
  ✓  HelmRelease     network/tailscale-operator
  ✓  HelmRelease     notifications/ntfy
  ✓  HelmRelease     onepassword-connect/onepassword-connect
  ✓  HelmRelease     spegel/spegel
  ✓  HelmRelease     storage/miroir
  ✓  HelmRelease     system-upgrade/tuppr
  ✓  GitRepository   agent-sandbox-system/agent-sandbox-crds
  ✓  GitRepository   flux-system/home-ops
  ✓  OCIRepository   agent-sandbox-system/agent-sandbox-controller
  ✓  OCIRepository   auth/dex-external
  ✓  OCIRepository   auth/dex-internal
  ✓  OCIRepository   cert-manager/cert-manager
  ✓  OCIRepository   chaski/chaski
  ✓  OCIRepository   default/barcodebuddy
  ✓  OCIRepository   default/error-pages-external
  ✓  OCIRepository   default/error-pages-internal
  ✓  OCIRepository   default/grocy
  ✓  OCIRepository   default/konflate
  ✓  OCIRepository   default/linkstack
  ✓  OCIRepository   default/mailpit
  ✓  OCIRepository   default/speedtest-tracker
  ✓  OCIRepository   default/yuvomi
  ✓  OCIRepository   downloads/prowlarr
  ✓  OCIRepository   downloads/radarr-anime
  ✓  OCIRepository   downloads/radarr-hd
  ✓  OCIRepository   downloads/radarr-uhd
  ✓  OCIRepository   downloads/sabnzbd
  ✓  OCIRepository   downloads/seerr
  ✓  OCIRepository   downloads/sonarr-anime
  ✓  OCIRepository   downloads/sonarr-hd
  ✓  OCIRepository   entertainment/jellyfin
  ✓  OCIRepository   external-secrets-system/external-secrets
  ✓  OCIRepository   flux-system/flux-operator
  ✓  OCIRepository   headlamp/headlamp
  ✓  OCIRepository   inteldeviceplugins-system/intel-device-plugins-operator
  ✓  OCIRepository   inteldeviceplugins-system/intel-gpu-plugin
  ✓  OCIRepository   kopiur-system/kopiur
  ✓  OCIRepository   kro-system/kro
  ✓  OCIRepository   kube-system/cilium
  ✓  OCIRepository   kube-system/descheduler
  ✓  OCIRepository   kube-system/metrics-server
  ✓  OCIRepository   kube-system/node-feature-discovery
  ✓  OCIRepository   kube-system/snapshot-controller
  ✓  OCIRepository   monitoring/capacitor
  ✓  OCIRepository   monitoring/grafana
  ✓  OCIRepository   monitoring/prometheus-operator-crds
  ✓  OCIRepository   monitoring/vector
  ✓  OCIRepository   monitoring/victoria-logs-cluster
  ✓  OCIRepository   monitoring/victoria-metrics-k8s-stack
  ✓  OCIRepository   network/cloudflared
  ✓  OCIRepository   network/external-dns-dev
  ✓  OCIRepository   network/external-dns-nexus
  ✓  OCIRepository   network/gateway-helm
  ✓  OCIRepository   network/tailscale-operator
  ✓  OCIRepository   notifications/ntfy
  ✓  OCIRepository   spegel/spegel
  ✓  OCIRepository   storage/miroir
  ✓  OCIRepository   system-upgrade/tuppr
  ✓  HelmRepository  holmes/robusta
  ✓  HelmRepository  onepassword-connect/onepassword-connect

  ⚠ warnings (2)
    HelmRelease network/tailscale-operator: values not used by the chart
      operator
    HelmRelease spegel/spegel: values not used by the chart
      controllers

  ✓ 182 passed   0.5s passes (182 passed)
- [x] Validate Flux resources (flate test).....................................Passed
Detect hardcoded secrets (gitleaks)......................................Passed
Detect verified secrets (trufflehog).....................................Passed passes (flate, gitleaks, trufflehog)