### PR TITLE
fix: disable kustomize hash suffix for chaski-config ConfigMap

### DIFF
--- a/kubernetes/chaski/app/kustomization.yaml
+++ b/kubernetes/chaski/app/kustomization.yaml
@@ -6,6 +6,8 @@ configMapGenerator:
   - name: chaski-config
     files:
       - config.d/10-holmes.yaml
+    options:
+      disableNameSuffixHash: true
 resources:
   - ocirepository.yaml
   - helmrelease.yaml


### PR DESCRIPTION
The `configMapGenerator` in chaski's kustomization generates a ConfigMap with a hash suffix (`chaski-config-<hash>`), but the HelmRelease references `existingConfigMap: chaski-config` (without hash). Kustomize doesn't rewrite Helm values fields, so the ConfigMap was never found and the pod stayed in `ContainerCreating`.

Adding `options.disableNameSuffixHash: true` makes the generated ConfigMap name exactly `chaski-config`, matching the HelmRelease reference.

Closes the chaski failure identified in #813.