### PR TITLE
feat(monitoring): expose Alertmanager and VMAlert UIs via Gateway API

### DIFF
--- a/kubernetes/monitoring/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/monitoring/victoria-metrics/app/httproute.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - alerts.whoverse.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: vmalertmanager-victoria-metrics
+          port: 9093
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmalert
+  namespace: monitoring
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - vmalert.whoverse.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: vmalert-victoria-metrics
+          port: 8080

--- a/kubernetes/monitoring/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/monitoring/victoria-metrics/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - httproute.yaml
   - ocirepository.yaml
   - ../config/externalsecret-discord.yaml
   - ../config/externalsecret-telegram.yaml


### PR DESCRIPTION
Exposes the VictoriaMetrics alerting UIs internally via Gateway API:

- **`alerts.whoverse.dev`** → `vmalertmanager-victoria-metrics:9093` (Alertmanager web UI)
- **`vmalert.whoverse.dev`** → `vmalert-victoria-metrics:8080` (VMAlert rule UI)

The `externalUrl` on Alertmanager was already set to `https://alerts.whoverse.dev` but had no route — this completes that config.

### Validation
- `flate test all`: 182/182 passed
- `pre-commit`: gitleaks + trufflehog + flate-test all passed