### PR TITLE
feat(reloader): add Stakater Reloader for auto-restarting pods on ConfigMap/Secret change

### DIFF
--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - inteldeviceplugins-system
   - kopiur-system
   - kro-system
+  - reloader

--- a/kubernetes/reloader/kustomization.yaml
+++ b/kubernetes/reloader/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ns.yaml
+  - reloader/ks.yaml

--- a/kubernetes/reloader/ns.yaml
+++ b/kubernetes/reloader/ns.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    homelab.whoverse.dev/component: infrastructure

--- a/kubernetes/reloader/reloader/app/helmrelease.yaml
+++ b/kubernetes/reloader/reloader/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+  namespace: reloader
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: reloader
+    namespace: reloader
+  install:
+    createNamespace: false
+    crds: CreateReplace
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  values:
+    reloader:
+      watchGlobally: true
+      reloadOnCreate: true

--- a/kubernetes/reloader/reloader/app/kustomization.yaml
+++ b/kubernetes/reloader/reloader/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ocirepository.yaml

--- a/kubernetes/reloader/reloader/app/ocirepository.yaml
+++ b/kubernetes/reloader/reloader/app/ocirepository.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: reloader
+  namespace: reloader
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "2.2.14"
+    digest: sha256:31bd8b82ac350078704e233706a21aec1f0906974febf0a1cc4ac1f3b83063f4
+  url: oci://ghcr.io/stakater/charts/reloader

--- a/kubernetes/reloader/reloader/ks.yaml
+++ b/kubernetes/reloader/reloader/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: reloader
+  namespace: reloader
+spec:
+  interval: 30m
+  path: "./kubernetes/reloader/reloader/app"
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+    namespace: flux-system
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: reloader-reloader
+      namespace: reloader
+  timeout: 10m
+  wait: true
+  prune: true


### PR DESCRIPTION
## Summary

Deploys [Stakater Reloader](https://github.com/stakater/Reloader) — a Kubernetes controller that watches ConfigMaps and Secrets and automatically triggers rolling restarts on workloads that reference them.

## Changes

- New  namespace directory following standard system-component pattern
- : ghcr.io/stakater/charts/reloader chart v2.2.14
- : , 
- Adds  to top-level 

## Notes

- The repo already had  annotation on the chaski deployment — this PR makes the controller actually exist via GitOps
- Reloader will watch all namespaces and restart any Deployment/StatefulSet/DaemonSet with the auto annotation when its referenced ConfigMaps/Secrets change