### PR TITLE
feat(entertainment): hard-pin jellyfin to whoverse-w1

### DIFF
--- a/kubernetes/entertainment/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/entertainment/jellyfin/app/helmrelease.yaml
@@ -31,20 +31,13 @@ spec:
         pod:
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 100
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: kubernetes.io/hostname
                         operator: In
                         values:
                           - whoverse-w1
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      app.kubernetes.io/name: jellyfin
-                  topologyKey: kubernetes.io/hostname
         containers:
           jellyfin:
             image:


### PR DESCRIPTION
## Summary
Replace `preferred` nodeAffinity (weight 100) with `required` so jellyfin cannot be scheduled on cp1/cp2 (zimaboards, weak CPU) or w2 (no i915 GPU) when whoverse-w1 is unavailable. Drop the now-redundant `podAntiAffinity` block (`strategy: Recreate` + hard pin already guarantees a single pod).

## Why
Jellyfin requires Intel GPU (`gpu.intel.com/i915: "1"`) for hardware transcode and meaningful CPU headroom for software transcode. Currently:
- **cp1/cp2** (zimaboards): insufficient CPU for transcode
- **w2**: lacks the i915 GPU entirely
- **w1**: only node with both

A `preferred` affinity is the only guard today — if w1 is drained during a Flux drift or restart, the pod silently lands on an unfit node.

## Change
`kubernetes/entertainment/jellyfin/app/helmrelease.yaml` — single file, +3/-10 lines:

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: kubernetes.io/hostname
              operator: In
              values:
                - whoverse-w1
```

## Validation
- `pre-commit run --all-files` — passed (flate, gitleaks, trufflehog)
- `just flate-test` — 185 passed (same 2 pre-existing warnings on unrelated components)

## Effects
| Node | Before | After |
|---|---|---|
| whoverse-w1 | preferred | **required** |
| whoverse-w2 (no GPU) | eligible if w1 down | **blocked** |
| whoverse-cp1/cp2 (weak CPU) | eligible if w1 down | **blocked** |

Failure mode improves: if w1 is offline, jellyfin sits `Pending` with `FailedScheduling` instead of silently landing where transcode can't run.