### PR TITLE
chore(storage): flip default SC from miroir-replicated to ceph-rbd

### DIFF
--- a/kubernetes/storage/miroir/config/storageclass-replicated.yaml
+++ b/kubernetes/storage/miroir/config/storageclass-replicated.yaml
@@ -3,8 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: miroir-replicated
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+  annotations: {}
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/kubernetes/storage/rook-ceph/app/helmrelease-cluster.yaml
+++ b/kubernetes/storage/rook-ceph/app/helmrelease-cluster.yaml
@@ -100,7 +100,7 @@ spec:
         storageClass:
           enabled: true
           name: ceph-rbd
-          isDefault: false
+          isDefault: true
           reclaimPolicy: Delete
           allowVolumeExpansion: true
           volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary

Flip the cluster-default StorageClass in preparation for sabnzbd/radarr-hd cutover from miroir to ceph.

### Changes
- : remove  annotation
- : set  →  on ceph-rbd storageClass

### Why
bjw-s app-template creates PVCs with the cluster-default StorageClass. After this flip, sabnzbd and radarr-hd's recreated config PVCs will land on ceph-rbd automatically.