### PR TITLE
chore(kopiur): revert sabnzbd and radarr-hd to miroir backup component

### DIFF
--- a/kubernetes/downloads/radarr-hd/ks.yaml
+++ b/kubernetes/downloads/radarr-hd/ks.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   targetNamespace: downloads
   components:
-        - ../../../components/kopiur/backup-ceph
+        - ../../../components/kopiur/backup
   interval: 15m
   path: "./kubernetes/downloads/radarr-hd/app"
   postBuild:

--- a/kubernetes/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/downloads/sabnzbd/ks.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   targetNamespace: downloads
   components:
-        - ../../../components/kopiur/backup-ceph
+        - ../../../components/kopiur/backup
   interval: 15m
   path: "./kubernetes/downloads/sabnzbd/app"
   postBuild:


### PR DESCRIPTION
Switch sabnzbd and radarr-hd back to backup/ (miroir) component, aligned with default SC remaining on miroir-replicated.