### PR TITLE
fix(renovate): re-enable automerge for pre-1.0 patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,11 +28,20 @@
   ],
   "packageRules": [
     {
-      "description": "Auto-merge patch updates silently (excluding pre-1.0)",
+      "description": "Auto-merge patch updates silently",
       "matchUpdateTypes": [
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Pre-1.0 releases: auto-merge patch updates only (SemVer bugfixes; 0.x minor bumps may break)",
+      "matchCurrentVersion": "/^0/",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "automerge": true,
       "automergeType": "branch"
     },


### PR DESCRIPTION
The pre-1.0 guard (matchCurrentVersion: '!/^0/') also blocked 0.x patch
bumps (e.g. 0.1.2 -> 0.1.3), which are SemVer bugfixes and safe to
automerge. Add a dedicated rule that auto-merges patch updates only for
pre-1.0 releases; 0.x minor/digest/major stays excluded since those may
contain breaking changes.
