### PR TITLE
fix(kopiur): drop url mapping from kopia-ui-auth pushsecret

### DIFF
--- a/kubernetes/kopiur-system/kopiur/repository/pushsecret.yaml
+++ b/kubernetes/kopiur-system/kopiur/repository/pushsecret.yaml
@@ -24,8 +24,3 @@ spec:
         remoteRef:
           remoteKey: kopia-ui-auth
           property: password
-    - match:
-        secretKey: url
-        remoteRef:
-          remoteKey: kopia-ui-auth
-          property: url


### PR DESCRIPTION
The source Secret whoverse-kopia-ui-auth is generated by the kopiur
controller and only contains username/password, so the url mapping
could never be populated and left the PushSecret in a permanent
Errored state (set secret failed: secret key url does not exist).

The url hint stays as a manual field in the 1Password item.
