### PR TITLE
docs(agents): refresh AGENTS.md and skills for current repo state

### DIFF
--- a/.agents/skills/home-ops-add-new-app/SKILL.md
+++ b/.agents/skills/home-ops-add-new-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: home-ops-add-new-app
-description: Use when adding a new application to the home-ops Kubernetes GitOps repository - creates directory structure, ks.yaml, helmrelease.yaml, externalsecret.yaml, httproute.yaml, and kustomization.yaml for a new app following the bjw-s app-template pattern
+description: Use when adding a new application to the home-ops Kubernetes GitOps repository - creates directory structure, ks.yaml, ocirepository.yaml, helmrelease.yaml, externalsecret.yaml, httproute.yaml, and kustomization.yaml for a new app
 ---
 
 # Adding a New App to home-ops
@@ -19,30 +19,36 @@ Where:
 - `{namespace}` = Kubernetes namespace (e.g. `downloads`, `entertainment`, `default`)
 - `{component}` = app name (e.g. `sonarr-hd`, `plex`)
 
-If the namespace doesn't exist yet, also create `ns.yaml` and `kustomization.yaml` at the namespace level (see existing namespaces for pattern).
+If the namespace doesn't exist yet, also create `ns.yaml` and `kustomization.yaml` at the namespace level (see existing namespaces for pattern), and add the namespace to the top-level `kubernetes/kustomization.yaml` aggregator.
 
 ## Step 2: Create `ks.yaml` (Flux Kustomization)
 
 ```yaml
----
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: {component}
   namespace: {namespace}
 spec:
-  interval: 15m
+  targetNamespace: {namespace}
+  components:
+    - ../../../components/kopiur/backup   # only if the app has persistent data (PVCs)
+  interval: 30m
   path: "./kubernetes/{namespace}/{component}/app"
+  postBuild:
+    substitute:
+      APP: {component}
   sourceRef:
     kind: GitRepository
     name: home-ops
     namespace: flux-system
-  dependsOn:
-    - name: {dependency}  # optional: e.g. {namespace}-database
   timeout: 10m
   wait: true
   prune: true
 ```
+
+- `components: ../../../components/kopiur/backup` wires the kopiur `Restore` populator + snapshot policy into the app's PVCs (backup-enabled apps only — skip for infra/storage components; compare with a similar existing app).
+- `postBuild.substitute: APP: {component}` — the kopiur component files use the `${APP}` placeholder, so the **component name must match the PVC/HelmRelease name** for the restore to line up.
 
 Then reference this in the namespace-level `kustomization.yaml`:
 
@@ -54,45 +60,59 @@ resources:
   - {component}/ks.yaml
 ```
 
-And add the namespace to the top-level `kubernetes/kustomization.yaml` aggregator:
+## Step 3: Create `app/ocirepository.yaml` (chart source)
+
+Apps pull the bjw-s app-template chart as an OCI artifact with cosign verification (see `home-ops-app-pattern`):
 
 ```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - {namespace}
-  # ...other namespaces
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: {component}
+  namespace: {namespace}
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "5.0.1"        # pin explicitly (Renovate manages)
+    digest: sha256:...
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token.actions.githubusercontent.com$
+        subject: ^https://github.com/bjw-s-labs/helm-charts/.github/workflows/chart-release-steps.yaml@.*$
 ```
 
-## Step 3: Create resource files in `app/`
+## Step 4: Create `app/helmrelease.yaml`
 
-See `home-ops-app-pattern` for the bjw-s HelmRelease shape.
+`helm.toolkit.fluxcd.io/v2` with `chartRef` pointing at the OCIRepository, values per `home-ops-app-pattern`.
 
-Optional files (create only if needed):
+## Step 5: Optional resource files
+
 - `app/externalsecret.yaml` — for secrets (see `home-ops-external-secrets`)
 - `app/httproute.yaml` — for ingress (see `home-ops-create-httproute`)
 - `app/config/` — extra ConfigMaps/Secrets
-- `app/repository/` — additional HelmRepository/OCIRepository sources
+- `app/snapshotpolicy.yaml` / `app/restore.yaml` — only if not using the `kopiur/backup` component (default path is the component)
 
-## Step 4: Create `app/kustomization.yaml`
+## Step 6: Create `app/kustomization.yaml`
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - ocirepository.yaml
   # add externalsecret.yaml, httproute.yaml as needed
 ```
 
-## Step 5: Add to namespace-level kustomization
-
-Edit `kubernetes/{namespace}/kustomization.yaml` and add the new component's `ks.yaml` reference.
-
-## Step 6: Deploy
+## Step 7: Deploy
 
 ```bash
-# Local validation (matches CI)
-kustomize build kubernetes | kubeconform -strict -ignore-missing-schemas
+# Local validation (matches pre-commit gate)
+just flate-test --allow-missing-secrets
 
 # Direct apply for quick iteration
 kubectl apply -k kubernetes/{namespace}/{component}/app
@@ -108,6 +128,7 @@ git push
 
 - **`metadata.namespace` in `ks.yaml` MUST match the parent namespace directory** (enforced by pre-commit hook)
 - The namespace's `kustomization.yaml` must reference `ns.yaml` **first** (enforced)
-- `bjw-s/app-template` chart structure — see `home-ops-app-pattern` skill
-- App chart version: pin explicitly (don't use `latest`)
-- Use `./kubernetes/{namespace}/{component}/app` for `spec.path` (2-level path from repo root)
+- `helmrelease.yaml` uses `helm.toolkit.fluxcd.io/v2` + `chartRef` (OCI) — not `chart.spec` with a HelmRepository
+- **`spec.path`** is a 2-level path from repo root: `./kubernetes/{namespace}/{component}/app`
+- If the app has PVCs and uses the `kopiur/backup` component, `metadata.name` of the HelmRelease/PVC must equal the `APP` substitute value
+- Run `just flate-test` after creating files; the pre-commit hook enforces the structure rules on commit

--- a/.agents/skills/home-ops-app-pattern/SKILL.md
+++ b/.agents/skills/home-ops-app-pattern/SKILL.md
@@ -1,27 +1,70 @@
 ---
 name: home-ops-app-pattern
-description: Use when authoring a HelmRelease for an application using the bjw-s app-template chart - the standard chart shape used across all apps in the home-ops repository
+description: Use when authoring a HelmRelease for an application in the home-ops repository - the standard OCI chartRef + bjw-s app-template values shape used across all apps
 ---
 
-# App Deployment Pattern (bjw-s app-template)
+# App Deployment Pattern (bjw-s app-template via OCI)
 
-Every application in this repo uses the [bjw-s app-template](https://github.com/bjwjwj/helm-charts) chart. This skill documents the canonical shape.
+Every application in this repo runs the [bjw-s app-template](https://github.com/bjw-s-labs/helm-charts) chart, delivered as an **OCI chart** (`helm.toolkit.fluxcd.io/v2` + `chartRef`). No HelmRepository chart sources for apps — charts come from `ghcr.io/bjw-s-labs/helm/app-template` with cosign signature verification.
 
-## Chart reference
+## Chart source — `app/ocirepository.yaml`
+
+Each app pins its own `OCIRepository` (same namespace as the app):
 
 ```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: {app}
+  namespace: {namespace}
 spec:
-  chart:
-    spec:
-      chart: app-template
-      version: "4.5.0"   # pin explicitly
-      sourceRef:
-        kind: HelmRepository
-        name: bjw-s
-        namespace: flux-system
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "5.0.1"          # pin explicitly (Renovate updates via PR)
+    digest: sha256:...    # pin digest
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token.actions.githubusercontent.com$
+        subject: ^https://github.com/bjw-s-labs/helm-charts/.github/workflows/chart-release-steps.yaml@.*$
 ```
 
-## Standard values structure
+## HelmRelease — `app/helmrelease.yaml`
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {app}
+  namespace: {namespace}
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: {app}            # matches the OCIRepository above, same namespace
+    namespace: {namespace}
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  values:
+    ...
+```
+
+**Standard values structure** (bjw-s app-template v4 shape):
 
 ```yaml
 spec:
@@ -31,50 +74,58 @@ spec:
         containers:
           {app}:
             image:
-              repository: ...
-              tag: ...
-            env: ...
+              repository: ghcr.io/linuxserver/sonarr
+              tag: ...        # pin explicitly
+            env:
+              TZ: America/Chicago
     service:
       {app}:
         controller: {app}
         ports:
           http:
-            port: ...
+            port: 80
     persistence:
       config:
         type: persistentVolumeClaim
-        storageClass: ceph-rbd
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        dataSourceRef:
+          apiGroup: kopiur.home-operations.com
+          kind: Restore
+          name: {app}
 ```
 
 ## Conventions
 
 - **`{app}`** is the controller/workload name (e.g. `sonarr-hd`, `plex`)
-- **`storageClass`**: use `ceph-rbd` (primary, distributed) or `openebs-hostpath` (local, faster)
-- **`image.tag`**: pin explicitly; Renovate manages updates via PR
-- **`image.repository`**: full image path (e.g. `ghcr.io/linuxserver/sonarr`)
-- **Service ports**: name them (`http`, not `80`); bjw-s template wires them up
+- **`image.tag`**: pin explicitly (digest or tag); Renovate manages updates via PR
+- **`image.repository`**: full image path
+- **Service ports**: name them (`http`, not `80`)
+- **storageClass**: use `miroir-replicated` (default SC) or `miroir-local`; do NOT reference `ceph-rbd`/`openebs-hostpath` — rook-ceph and openebs-localpv are disabled. Only set `storageClass` when you need a non-default class; the cluster default (`miroir-replicated`) applies otherwise.
+- **Backup persistence**: apps with PVCs use the kopiur `Restore` populator via `dataSourceRef` (as above) — added automatically when the `ks.yaml` includes the `kopiur/backup` component (see `home-ops-add-new-app`). Jellyfin uses an NFS `cache` volume (`type: nfs`, `globalMounts`) in addition — see its `helmrelease.yaml` for the shape.
 
 ## Common extras
 
 ```yaml
     # Probes
-    containers:
+    controllers:
       {app}:
-        probes:
-          liveness:
-            tcpSocket:
-              port: http
-          readiness:
-            tcpSocket:
-              port: http
+        containers:
+          {app}:
+            probes:
+              liveness:
+                tcpSocket:
+                  port: http
+              readiness:
+                tcpSocket:
+                  port: http
 
-    # Resources (bjw-s uses simpleResources)
+    # Resources
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 1000m
         memory: 512Mi
 
     # ServiceAccount / RBAC

--- a/.agents/skills/home-ops-create-httproute/SKILL.md
+++ b/.agents/skills/home-ops-create-httproute/SKILL.md
@@ -1,24 +1,27 @@
 ---
 name: home-ops-create-httproute
-description: Use when creating an HTTPRoute resource for Gateway API ingress in home-ops - covers per-app routing, dual gateway access (internal + external), shared routes, and gateway references
+description: Use when creating an HTTPRoute resource for Gateway API ingress in home-ops - covers per-app routing, dual gateway access (internal + external), listener scoping, and shared routes
 ---
 
 # Creating HTTPRoutes
 
-HTTPRoutes define how traffic flows from Envoy Gateway to a Kubernetes Service. Two gateways exist:
+HTTPRoutes define how traffic flows from Envoy Gateway to a Kubernetes Service. Two gateways exist, both **HTTPS**:
 
-- **`internal`** (Tailscale, `*.whoverse.dev`, section `https`) — internal/LAN access
-- **`external`** (Cloudflare Tunnel, `*.whoverse.nexus`, section `http`) — public access
+- **`internal`** (Tailscale, `*.whoverse.dev`, listener `https`) — internal/LAN access
+- **`external`** (Cloudflare Tunnel, listener `whoverse-nexus` for `*.whoverse.nexus`, listener `beee-gay` for `*.beee.gay`) — public access; TLS terminated at origin with Cloudflare Origin CA certs
 
 ## File location
 
 - **Per-app**: `kubernetes/{namespace}/{component}/app/httproute.yaml`
 - **Shared**: `kubernetes/network/envoy-gateway/config/httproutes/`
 
-## Internal-only HTTPRoute
+## Default convention — name-only parentRefs
+
+The standard pattern is `parentRefs` by gateway name **without `sectionName`** (hostname matching routes traffic to the right listener). The `{app}` in `backendRefs` is the bjw-s app-template service name — which equals the HelmRelease/controller name.
+
+### Internal-only
 
 ```yaml
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -28,7 +31,6 @@ spec:
   parentRefs:
     - name: internal
       namespace: network
-      sectionName: https   # HTTPS listener
   hostnames:
     - {app}.whoverse.dev
   rules:
@@ -37,14 +39,13 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {app}-service
+        - name: {app}
           port: 80
 ```
 
-## External-only HTTPRoute
+### External-only
 
 ```yaml
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -54,23 +55,21 @@ spec:
   parentRefs:
     - name: external
       namespace: network
-      sectionName: http    # Cloudflare handles TLS
   hostnames:
-    - {app}.whoverse.nexus
+    - {app}.whoverse.nexus   # or {app}.beee.gay for the second public domain
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {app}-service
+        - name: {app}
           port: 80
 ```
 
-## Dual access (both internal and external)
+### Dual access (both internal and external)
 
 ```yaml
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -80,10 +79,8 @@ spec:
   parentRefs:
     - name: internal
       namespace: network
-      sectionName: https
     - name: external
       namespace: network
-      sectionName: http
   hostnames:
     - {app}.whoverse.dev     # Internal
     - {app}.whoverse.nexus   # External
@@ -93,9 +90,22 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {app}-service
+        - name: {app}
           port: 80
 ```
+
+## When to scope with `sectionName`
+
+`sectionName` is only needed to bind a route to a **specific listener**. Current usage is limited to explicit scoping on the internal gateway's `https` listener (e.g. `monitoring/victoria-metrics` routes for `alerts.whoverse.dev` / `vmalert.whoverse.dev`):
+
+```yaml
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+```
+
+Do **not** use `sectionName: http` — the external gateway no longer has an HTTP listener (TLS is terminated at origin).
 
 ## DNS behavior
 
@@ -103,6 +113,7 @@ External-DNS watches HTTPRoutes attached to either gateway and creates the appro
 
 - `*.whoverse.dev` → A record pointing to Tailscale IP (DNS-only)
 - `*.whoverse.nexus` → Cloudflare proxy (CDN enabled)
+- `*.beee.gay` → Cloudflare proxy
 
 If a specific record exists (`app.whoverse.dev`), it overrides the wildcard catchall.
 

--- a/.agents/skills/home-ops-flate/SKILL.md
+++ b/.agents/skills/home-ops-flate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: home-ops-flate
-description: Use flate to validate and diff Flux CD Kubernetes resources — replaces kubeconform for structural validation, image tracking, and PR previews
+description: Use flate to validate and diff Flux CD Kubernetes resources — the local validation gate (pre-commit + just recipes); CI still runs kustomize build + kubeconform
 ---
 
 # flate — Flux Rendering and Diff Tool
@@ -75,12 +75,13 @@ flate get images -p kubernetes   # list all container images
 
 ## Pre-commit Hook
 
-The repo ships a `flate-test` hook in `.pre-commit-config.yaml` that copies `kubernetes/` to a temp dir before validation (avoiding git-related issues):
+The repo ships a `flate-test` hook in `.pre-commit-config.yaml` (also run via `just flate-test`):
 
 ```yaml
 - id: flate-test
   name: Validate Flux resources (flate test)
-  entry: bash -c 'tmp=$(mktemp -d) && trap "rm -rf $tmp" EXIT && cp -r kubernetes "$tmp/kubernetes" && flate test all -p "$tmp/kubernetes"'
+  description: Validate all Kustomizations and HelmReleases
+  entry: flate test all -p kubernetes
   language: system
   pass_filenames: false
   stages: [pre-commit]

--- a/.agents/skills/home-ops-network-troubleshooting/SKILL.md
+++ b/.agents/skills/home-ops-network-troubleshooting/SKILL.md
@@ -6,8 +6,8 @@ description: Use when diagnosing network/ingress issues in home-ops - Gateway/Ta
 # Network Troubleshooting
 
 Two gateways:
-- **internal** — Tailscale (`*.whoverse.dev`)
-- **external** — Cloudflare Tunnel (`*.whoverse.nexus`)
+- **internal** — Tailscale (`*.whoverse.dev`), HTTPS listener `https`
+- **external** — Cloudflare Tunnel (`*.whoverse.nexus` + `*.beee.gay`), HTTPS at origin (Cloudflare Origin CA); the gateway Service is ClusterIP, reached only by cloudflared
 
 ## Gateway / Envoy
 
@@ -22,6 +22,8 @@ kubectl get envoyproxy -n network
 kubectl describe envoyproxy internal-proxy-config -n network
 kubectl describe envoyproxy external-proxy-config -n network
 ```
+
+Note: `envoy-external` is **ClusterIP** (cloudflared talks to it in-cluster); only `envoy-internal` is a Tailscale LoadBalancer.
 
 ## Tailscale
 
@@ -71,6 +73,9 @@ dig {app}.whoverse.nexus
 kubectl get certificate -n network whoverse-dev-wildcard-tls
 kubectl describe certificate -n network whoverse-dev-wildcard-tls
 
+# External gateway certs (Cloudflare Origin CA, from 1Password via ExternalSecret)
+kubectl get secret -n network whoverse-nexus-wildcard-tls beee-gay-wildcard-tls
+
 # cert-manager logs
 kubectl logs -n cert-manager -l app.kubernetes.io/name=cert-manager
 ```
@@ -91,14 +96,15 @@ kubectl get cm cilium-config -n kube-system -o yaml | grep -A1 socketLB
 files.whoverse.dev       → specific record (Tailscale IP, overrides wildcard)
 app.whoverse.dev         → specific record (Tailscale IP, overrides wildcard)
 unmapped.whoverse.dev    → uses wildcard catchall
+*.beee.gay               → second public domain (Cloudflare proxy)
 ```
 
 ## Common failure modes
 
 | Symptom | Check |
 |---|---|
-| `502 Bad Gateway` from external | `kubectl logs -n network -l app.kubernetes.io/name=external-dns-nexus` for tunnel token issues |
+| `502 Bad Gateway` from external | `kubectl logs -n network -l app.kubernetes.io/name=external-dns-nexus` for tunnel token issues; also check cloudflared pods (`kubectl get pods -n network -l app.kubernetes.io/name=cloudflared`) |
 | `connection refused` on internal | `kubectl get svc envoy-internal -n network` EXTERNAL-IP must be 100.x |
-| HTTPRoute `Accepted: False` | `kubectl describe httproute` → check parentRefs and listener section |
+| HTTPRoute `Accepted: False` | `kubectl describe httproute` → check parentRefs and listener section (external listeners: `whoverse-nexus`, `beee-gay`; internal: `https`) |
 | DNS not resolving | `dig` to confirm record exists; check external-dns logs for rate-limit / API token errors |
 | Cert not issuing | `kubectl describe certificate` → check ACME challenge and cert-manager logs |

--- a/.agents/skills/home-ops-worktree-workflow/SKILL.md
+++ b/.agents/skills/home-ops-worktree-workflow/SKILL.md
@@ -121,7 +121,7 @@ just worktree-clean <branch-name>
 
 - **`.env` is not shared** across worktrees. Always regenerate: `mise run secrets:env`
 - **SOPS decryption works natively** — worktrees share the `.git` dir, personal age key at `~/.config/sops/age/keys.txt`
-- **mise tools are user-level**, not repo-level — they work across all worktrees
+- **mise.toml pins the toolchain** (repo-level); the mise binary is user-level — installs are cached globally, so they work across all worktrees
 - **`git worktree remove` fails if the worktree has uncommitted changes** — commit or stash first
 - **Pre-commit hooks** are installed per-worktree — run `mise run hooks:install` in each new worktree
 - **Renovate branches** can be checked out with `just worktree-add origin/renovate/...` for local validation before merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Primary agent instructions for the home-ops repository. Covers Kubernetes infras
 
 ## Tooling
 
-This repo's `mise.toml` pins only the **pre-commit stack** (`pre-commit`, `gitleaks`, `trufflehog`). User-level CLI tools (`kubectl`, `helm`, `helmfile`, `flux`, `cilium`, `k9s`, `sops`, `age`, `jq`, `yq`, `just`, `kustomize`, `kubeconform`) are managed outside the repo via `~/.config/mise/conf.d/`.
+The repo's `mise.toml` pins the full toolchain: `talosctl`, `talhelper`, `kubectl`, `helm`, `helmfile`, `flux2`, `cilium-cli`, `k9s`, `sops`, `age`, `just`, `jq`, `yq`, `pre-commit`, `gitleaks`, `trufflehog`, `k8sgpt`, `kopia`, `flux-operator`, `flux-operator-mcp`, `kubeconform`, `flate`, `crane`. Note: `kustomize` is **not** pinned — use `flate` for local rendering/validation (CI installs kustomize itself).
 
 ```bash
 mise install                # installs pre-commit hook (auto-runs when .git exists)
@@ -41,7 +41,7 @@ request.
 | `gh pr merge …` (any flag combo: `--merge`, `--squash`, `--rebase`, `--auto`, `--delete-branch`) | Merges publish to `main` and trigger Flux reconciliation cluster-wide. |
 | `git push` to `main` / `master` (including Renovate's auto-merge targets) | Direct push bypasses PR review. |
 | `git push --force` / `--force-with-lease` to any shared branch | Rewrites published history. |
-| `git reset --hard` / `git commit --amand` on a published commit | Destroys or rewrites published history. |
+| `git reset --hard` / `git commit --amend` on a published commit | Destroys or rewrites published history. |
 | `git branch -D` on a branch that exists on `origin` | Deletes shared work. |
 | `kubectl delete` against `flux-system`, `kube-system`, `cert-manager`, `external-secrets-system`, `storage`, `network`, `monitoring`, `auth` — or any resource with `reconcile.external-secrets.io/managed=true` | Cluster state damage; some are irrecoverable without reinstall. |
 | `kubectl scale --replicas=0` or `kubectl drain` on control-plane / storage nodes | Cluster availability impact. |
@@ -96,15 +96,22 @@ Branch naming:
 
 ## Architecture Overview
 
-- **GitOps Engine**: Flux CD with GitRepository (HTTPS, branch=main, poll interval; OCI artifact retained dormant as rollback insurance)
+- **GitOps Engine**: Flux CD deployed via Flux Operator (`FluxInstance/flux` in `flux-system`); `GitRepository home-ops` (HTTPS, branch=main, poll interval; OCI artifact retained dormant as rollback insurance). The single `Kustomization/cluster` lives at `kubernetes/ks.yaml` and reconciles `./kubernetes`
 - **Resource Composition**: Kustomize layering with Helm charts
-- **Helm Charts**: bjw-s app-template for applications
+- **Helm Charts**: bjw-s app-template delivered via OCI — per-app `OCIRepository` (`oci://ghcr.io/bjw-s-labs/helm/app-template`, cosign-verified) + `helm.toolkit.fluxcd.io/v2` HelmRelease using `chartRef`
 - **Secrets**: External Secrets Operator syncing from 1Password Connect (`ClusterSecretStore: onepassword-connect`)
 - **Ingress**: Envoy Gateway with Gateway API HTTPRoutes
-  - External Gateway: Cloudflare Tunnel for public access (`*.whoverse.nexus`)
+  - External Gateway: Cloudflare Tunnel, TLS terminated at origin (Cloudflare Origin CA) — `*.whoverse.nexus` + `*.beee.gay`
   - Internal Gateway: Tailscale VPN with HA for private access (`*.whoverse.dev`)
 - **Networking**: Cilium CNI with BGP, Tailscale operator for VPN LoadBalancer
-- **Storage**: `ceph-rbd` (primary), `openebs-hostpath` (fallback)
+- **Storage**: miroir (`miroir-replicated` default, `miroir-local`); rook-ceph and openebs-localpv disabled (pending cluster reset); zot OCI registry
+
+### Networks
+
+| Network | Range | Notes |
+|---|---|---|
+| LAN (br0, native/untagged) | `192.168.2.0/24` | Talos nodes; API VIP `192.168.2.20` |
+| Tailscale | `100.x` | Internal gateway (`*.whoverse.dev`), pve-egress relay |
 
 ## Directory Structure
 
@@ -125,7 +132,7 @@ The Kubernetes directory follows a flat **Namespace → Component → Resources*
 - **component**: Single deployed unit (`sonarr-hd/`, `plex/`, `cilium/`)
 - **resources**: Actual K8s manifests (`helmrelease.yaml`, `externalsecret.yaml`, `httproute.yaml`, `config/`, `repository/`, `policies/`, etc.)
 
-A single Flux `Kustomization/cluster` reconciles `./` (the whole `kubernetes/` tree). There is no `apps/` or `infrastructure/` group directory.
+The `Kustomization/cluster` at `kubernetes/ks.yaml` reconciles `./kubernetes` (the whole tree). There is no `apps/` or `infrastructure/` group directory.
 
 ### File Types
 
@@ -143,37 +150,20 @@ A single Flux `Kustomization/cluster` reconciles `./` (the whole `kubernetes/` t
 3. No `**/ns.yaml` outside namespace level (except `bootstrap/`)
 4. Component `ks.yaml` `metadata.namespace` must match parent namespace directory
 
-### Tree
+### Layout guide
 
-```
-kubernetes/
-├── kustomization.yaml        # Top-level namespace aggregator
-├── entertainment/            # jellyfin + storage (NFS PVCs)
-├── default/                  # barcodebuddy, database, error-pages, grocy, mailpit, memos, speedtest-tracker
-├── downloads/                # prowlarr, radarr-*, recyclarr, sabnzbd, seerr, sonarr-*, storage
-├── sync/                     # seafile, storage
-├── agent-sandbox-system/
-├── auth/                     # dex-internal, dex-external, security-policies
-├── cert-manager/
-├── external-secrets-system/
-├── flux-system/              # webhook receiver
-├── headlamp/
-├── inteldeviceplugins-system/
-├── kopiur-system/            # Snapshot CRDs
-├── kube-system/              # cilium, descheduler, gvisor, metrics-server, nfd, snapshot-controller
-├── kyverno/                  # policies + rbac
-├── monitoring/               # capacitor, grafana, vector, victoria-logs, victoria-metrics
-├── network/                  # cloudflared, envoy-gateway, external-dns, pve-egress, tailscale
-├── onepassword-connect/
-├── spegel/                   # P2P image distribution
-├── storage/                  # rook-ceph, openebs-localpv
-├── system-upgrade/           # tuppr
-├── components/               # Cross-cutting bundles (e.g. kopiur)
-├── flux-config/              # Flux CD self-management (HelmRelease, GitRepository, cluster root)
-├── bootstrap/                # Cilium + Flux helmfile for first install
-├── scripts/                  # deploy-infrastructure.sh
-└── bootstrap.sh              # Initial Flux install (alternative to helmfile bootstrap)
-```
+The namespace list changes often — `ls kubernetes/` is the live view and the top-level `kubernetes/kustomization.yaml` aggregator is the authoritative list of active namespaces. Don't trust a static tree.
+
+Reconcile scope: everything under `kubernetes/` is app code except the meta dirs below. Layout follows the flat Namespace → Component → Resources hierarchy above; the pre-commit hook enforces rules 1–4.
+
+Meta directories (not reconciled as namespaces):
+
+| Dir | Purpose |
+|---|---|
+| `components/` | Cross-cutting Kustomize components (e.g. `kopiur/backup`), referenced via component `ks.yaml` `components:` |
+| `bootstrap/` | Cilium + Flux helmfile, one-shot first install |
+| `flux-config/` | Flux self-management: GitRepository, registry sources, sops (`flux-sops` Kustomization) |
+| `scripts/` | deploy-infrastructure.sh, add-yaml-modelines.py |
 
 ## Deployment Workflow
 
@@ -213,6 +203,13 @@ kubectl rollout restart deployment/<app> -n <namespace>
 | `just flux-sync` | Annotate OCIRepository + reconcile cluster (dormant) |
 | `just cilium-status` | `cilium status --wait` |
 | `just destroy-flux` | Remove all Flux resources (keeps cluster) |
+| `just flate-test` | Validate Flux resources (`flate test all`) — pre-commit gate |
+| `just flate-build` | Render all Flux objects to YAML |
+| `just flate-diff` | Diff rendered output against `main` |
+| `just bootstrap` | Full bootstrap: Cilium + Flux Operator + Flux self-management |
+| `just bootstrap-helmfile` | Cilium + Flux Operator via helmfile |
+| `just bootstrap-cilium` | Install Cilium CNI only |
+| `just bootstrap-sops-key` | Install Flux SOPS age key (one-shot per cluster rebuild) |
 | `just worktree-create <branch>` | Create feature branch worktree from `main` |
 | `just worktree-add <branch>` | Check out existing remote branch as worktree |
 | `just worktree-clean <branch>` | Remove worktree + local branch |
@@ -224,20 +221,18 @@ See `talos/AGENTS.md` for Talos recipes (`talos-gen`, `talos-apply`, `talos-boot
 
 **CI** runs in `.github/workflows/validate-kubernetes.yml`: `kustomize build` + `kubeconform` against `kubernetes/flux-config` and `kubernetes/` (root aggregator).
 
-**Local equivalent**:
+**Local equivalent** — flate is the primary gate (no `helm`/`kustomize`/`flux` binaries needed):
 
 ```bash
-# Install once (user-level via mise conf.d)
-mise install
+just flate-test                    # validate every Kustomization/HelmRelease/source
+just flate-test --allow-missing-secrets   # skip refs that only exist in the cluster
+just flate-build                   # render all resources
+just flate-diff                    # diff against main
+```
 
-# Validate a directory
-kustomize build kubernetes | kubeconform \
-  -strict \
-  -ignore-missing-schemas \
-  -schema-location default \
-  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+CI-equivalent kubeconform check (matches `.github/workflows/validate-kubernetes.yml`):
 
-# Or the two top-level dirs in a loop
+```bash
 for dir in kubernetes/flux-config kubernetes; do
   echo "=== $dir ==="
   kustomize build "$dir" | kubeconform -strict -ignore-missing-schemas \
@@ -256,6 +251,7 @@ done
   - `home-ops-network-troubleshooting` — Gateway/Tailscale/ExternalDNS/cert diagnostics
   - `home-ops-initial-bootstrap` — Cilium CA + Hubble TLS one-time setup
   - `home-ops-external-secrets` — 1Password Connect `ExternalSecret` convention
+  - `home-ops-flate` — flate validation and diff (the local validation gate)
   - `home-ops-worktree-workflow` — Isolation via git worktrees (load before any file changes)
 
 ## Workstation Secrets


### PR DESCRIPTION
- Tooling: mise.toml now pins the full toolchain (incl. flate); kustomize
  is no longer pinned locally
- Architecture: Flux Operator/FluxInstance, OCI chartRef delivery of
  bjw-s app-template, origin-TLS external gateway (+ *.beee.gay),
  miroir/zot storage (rook-ceph + openebs-localpv disabled)
- Directory section: replace static tree with layout guide (aggregator
  is the source of truth; meta dirs table)
- Justfile table: add flate + bootstrap recipes; Validation: lead with
  flate; See Also: add home-ops-flate
- Skills: rewrite app-pattern for v2/chartRef/OCIRepository; update
  add-new-app (ocirepository step, kopiur component, flate validation),
  create-httproute (name-only parentRefs, origin TLS, beee.gay),
  network-troubleshooting (ClusterIP envoy-external, origin certs),
  flate (pre-commit snippet), worktree (mise wording)
