### PR TITLE
fix(monitoring): depend on grafana-operator for CRDs-first rollout

### DIFF
--- a/kubernetes/monitoring/grafana/ks.yaml
+++ b/kubernetes/monitoring/grafana/ks.yaml
@@ -12,6 +12,10 @@ spec:
     kind: GitRepository
     name: home-ops
     namespace: flux-system
+  # Wait for grafana-operator to install its CRDs (grafana.integreatly.org)
+  # before applying Grafana/Dashboard/Datasource CRs.
+  dependsOn:
+    - name: grafana-operator
   timeout: 10m
   wait: true
   prune: true

--- a/kubernetes/monitoring/victoria-metrics/ks.yaml
+++ b/kubernetes/monitoring/victoria-metrics/ks.yaml
@@ -12,6 +12,10 @@ spec:
     kind: GitRepository
     name: home-ops
     namespace: flux-system
+  # The chart renders GrafanaDatasource CRs (defaultDatasources.grafanaOperator),
+  # so wait for the grafana-operator CRDs before rolling out.
+  dependsOn:
+    - name: grafana-operator
   targetNamespace: monitoring
   timeout: 10m
   wait: true


### PR DESCRIPTION
Follow-up to #841. Both kustomizations raced the operator install:

- `grafana/ks.yaml` → `dependsOn: grafana-operator` (applies Grafana/GrafanaDashboard/GrafanaDatasource CRs)
- `victoria-metrics/ks.yaml` → `dependsOn: grafana-operator` (chart now renders GrafanaDatasource CRs)

Matches the existing CRDs-first pattern (`victoria-metrics-scrapes` → `victoria-metrics`). Prevents failed dry-runs/health-check timeouts on missing `grafana.integreatly.org` CRDs.