### PR TITLE
fix(monitoring): un-pin victoriametrics-logs plugin (404 in grafana 12.3.1)

### DIFF
--- a/kubernetes/monitoring/grafana/app/grafana.yaml
+++ b/kubernetes/monitoring/grafana/app/grafana.yaml
@@ -73,5 +73,8 @@ spec:
                 # k8s-stack chart creates the VictoriaLogs GrafanaDatasource CR
                 # without plugin info (no version in its default entry), so we
                 # install it here rather than via the datasource CR.
+                # NOTE: no version pin — Grafana 12.3.1's background installer
+                # returns 404 for pinned versions (e.g. :0.30.1) even when the
+                # version exists in the catalog; bare name installs latest.
                 - name: GF_INSTALL_PLUGINS
-                  value: victoriametrics-logs-datasource:0.30.1
+                  value: victoriametrics-logs-datasource


### PR DESCRIPTION
Grafana 12.3.1's background installer crashes grafana with `failed to install plugin victoriametrics-logs-datasource:0.30.1@: 404: Plugin not found` — even though 0.30.1 exists in the catalog (checked grafana.com API). The pre-migration chart installed the plugin without a version (latest) and worked. Drop the pin; bare name installs latest. Fixes the grafana-deployment crash loop from #841.