### PR TITLE
feat(cilium): native routing + hubble-ui internal route

### DIFF
--- a/kubernetes/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/kube-system/cilium/app/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
   values:
     ipam:
       mode: kubernetes
+    routingMode: native
+    ipv4NativeRoutingCIDR: 10.244.0.0/16
+    autoDirectNodeRoutes: true
     kubeProxyReplacement: true
     bpf:
       masquerade: true
@@ -89,8 +92,7 @@ spec:
             requests:
               memory: 64Mi
         service:
-          type: NodePort
-          nodePort: 31234
+          type: ClusterIP
     prometheus:
       enabled: true
     envoy:

--- a/kubernetes/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/kube-system/cilium/app/httproute.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+  hostnames:
+    - "hubble.whoverse.dev"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: hubble-ui
+          port: 80

--- a/kubernetes/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/kube-system/cilium/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - httproute.yaml
   - ocirepository.yaml


### PR DESCRIPTION
- Switch datapath from VXLAN tunnel to native routing:
  routingMode: native, ipv4NativeRoutingCIDR: 10.244.0.0/16,
  autoDirectNodeRoutes: true (cross-node routes on the L2)
- Pod/service CIDRs stay un-advertised to the MikroTik (BGP advertises
  LB IPs only); egress remains masqueraded via bpf.masquerade
- Hubble UI: service type NodePort -> ClusterIP, expose at
  hubble.whoverse.dev via internal gateway HTTPRoute
