### PR TITLE
refactor(monitoring): run grafana ephemeral (drop PVC + Recreate)

### DIFF
--- a/kubernetes/monitoring/grafana/app/grafana.yaml
+++ b/kubernetes/monitoring/grafana/app/grafana.yaml
@@ -34,21 +34,12 @@ spec:
       use_pkce: "true"
       role_attribute_path: "contains(groups[*], 'admins') && 'Admin' || 'Viewer'"
 
-  persistentVolumeClaim:
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      storageClassName: miroir-replicated
-      resources:
-        requests:
-          storage: 2Gi
-
+  # Storage is intentionally ephemeral: everything (dashboards, datasources,
+  # folders, plugins, admin creds, OAuth) is declaratively driven by CRs/env,
+  # so there is no authoritative state to persist. Avoids the RWO PVC +
+  # Recreate dance and keeps the deployment stateless (RollingUpdate).
   deployment:
     spec:
-      # Recreate ensures the old pod fully releases the RWO PVC before the new
-      # pod starts (operator default is RollingUpdate).
-      strategy:
-        type: Recreate
       template:
         spec:
           containers:


### PR DESCRIPTION
grafana is fully declarative via CRs (dashboards/datasources/folders) and env (admin creds, OAuth, plugin install) — no authoritative state to persist.

- The operator creates `grafana-pvc` from `spec.persistentVolumeClaim` but never mounts it (v5.x behavior, verified in source), leaving a Pending WaitForFirstConsumer PVC and forcing RWO + Recreate rollouts
- Drop the claim + Recreate override → stateless deployment, RollingUpdate, no storage dependency
- Orphaned `grafana-pvc` will be deleted post-merge