### PR TITLE
fix(monitoring): correct vlagent excludeFilter (was blocking all log collection)

### DIFF
--- a/kubernetes/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -186,8 +186,10 @@ spec:
           # Attach pod labels (kubernetes.pod_labels.*) for filtering.
           includePodLabels: true
           # Don't collect vlagent's own logs (DaemonSet pods are named
-          # vlagent-victoria-metrics-<hash>).
-          excludeFilter: 'kubernetes.pod_name:!~"vlagent-victoria-metrics-.*"'
+          # vlagent-victoria-metrics-<hash>). Positive regex match: rows
+          # matching this expression are excluded (a !~ negation here would
+          # exclude every pod NOT named vlagent-*, i.e. all real logs).
+          excludeFilter: 'kubernetes.pod_name:~"vlagent-victoria-metrics-.*"'
         resources:
           requests:
             memory: 256Mi


### PR DESCRIPTION
The excludeFilter LogsQL expression is an include/exclude predicate where rows **matching** the expression are excluded.

`kubernetes.pod_name:!~"vlagent-victoria-metrics-.*"` excluded every pod whose name does *not* match vlagent's — i.e. **all real logs**. Verified live: collection stopped ~5s after DaemonSet start (05:54:14Z); only vlagent's own startup lines were ingested; 0 rows in the last 15 min.

Fix: positive match `kubernetes.pod_name:~"vlagent-victoria-metrics-.*"`.

On merge, the CR update restarts DaemonSet pods with the corrected filter; collection resumes from hostPath checkpoints. Metrics (VMPodScrape) and default alerting (VMRule) are already operational.