### PR TITLE
fix(monitoring): vmagent CPU alert — drop CPU limit, fix ntfy + cp scrapes

### DIFF
--- a/kubernetes/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -72,6 +72,16 @@ spec:
       spec:
         selectAllByDefault: true
         scrapeInterval: 30s
+        # No CPU limit: vmagent ran ~60-85m on 200m chart-default limit and hit
+        # it on 2026-08-06 (TooHighCPUUsage + TooHighGoroutineSchedulingLatency,
+        # ingestion throttled 13k -> 5.3k rows/s). CPU request bumped to match
+        # sustained usage; memory kept at chart defaults.
+        resources:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+          limits:
+            memory: 500Mi
 
     # Bundled exporters — auto-discovered via CRDs with selectAllByDefault
     kube-state-metrics:
@@ -106,19 +116,24 @@ spec:
     # talos/whoverse/talconfig.yaml) but serves self-signed certs (no
     # --tls-cert-file), so the scrape must skip verification. RBAC for the
     # vmagent SA (/metrics nonResourceURLs) is already chart-generated.
+    # scheme must be explicit https: tlsConfig only applies to TLS connections,
+    # without scheme the endpoint defaults to http and the secure ports answer
+    # 400 "Client sent an HTTP request to an HTTPS server" (TooManyScrapeErrors).
     kubeControllerManager:
       enabled: true
       vmScrape:
         spec:
           endpoints:
-            - tlsConfig:
+            - scheme: https
+              tlsConfig:
                 insecureSkipVerify: true
     kubeScheduler:
       enabled: true
       vmScrape:
         spec:
           endpoints:
-            - tlsConfig:
+            - scheme: https
+              tlsConfig:
                 insecureSkipVerify: true
 
     # Disable bundled Grafana — we deploy our own via grafana-operator.

--- a/kubernetes/notifications/ntfy/app/helmrelease.yaml
+++ b/kubernetes/notifications/ntfy/app/helmrelease.yaml
@@ -46,6 +46,14 @@ spec:
               - name: http
                 containerPort: 80
                 protocol: TCP
+              # Prometheus metrics listener (ntfy --metrics-listen-http).
+              # The old ServiceMonitor scraped port 80 /metrics and got the
+              # SPA web UI HTML back (~100 parse errors per scrape, flooding
+              # vmagent logs/CPU). Metrics are disabled by default in ntfy;
+              # enabling this listener is what makes /metrics real.
+              - name: metrics
+                containerPort: 9090
+                protocol: TCP
             env:
               TZ:
                 value: America/Chicago
@@ -57,6 +65,8 @@ spec:
                 value: "true"
               NTFY_ENABLE_LOGIN:
                 value: "true"
+              NTFY_METRICS_LISTEN_HTTP:
+                value: ":9090"
             resources:
               requests:
                 cpu: 50m
@@ -71,6 +81,10 @@ spec:
           http:
             port: 80
             targetPort: http
+            protocol: TCP
+          metrics:
+            port: 9090
+            targetPort: metrics
             protocol: TCP
         labels:
           app.kubernetes.io/name: ntfy
@@ -111,7 +125,7 @@ spec:
       main:
         enabled: true
         endpoints:
-          - port: http
+          - port: metrics
             path: /metrics
             interval: 30s
         service:


### PR DESCRIPTION
vmagent hit its 200m chart-default CPU limit on 2026-08-06
(TooHighCPUUsage/TooHighGoroutineSchedulingLatency, ingestion
throttled 13k -> 5.3k rows/s). Root causes:

- vmagent: remove limits.cpu (request 200m, memory unchanged). CPU
  request bumped to match ~200m sustained usage; the 50m/200m default
  was too tight for the current scrape volume.
- ntfy: ServiceMonitor scraped port 80 /metrics and got the SPA web UI
  HTML back (~100 parse errors/scrape). Enable ntfy's metrics listener
  (NTFY_METRICS_LISTEN_HTTP=:9090), add metrics port to container +
  service, point ServiceMonitor at it.
- kube-controller-manager/kube-scheduler: tlsConfig.insecureSkipVerify
  was set but scheme defaulted to http, so the secure ports answered
  400 'Client sent an HTTP request to an HTTPS server'. Set scheme:
  https explicitly.
