### PR TITLE
chore(talos): enable terminated pod GC (threshold 100)

### DIFF
--- a/talos/whoverse/talconfig.yaml
+++ b/talos/whoverse/talconfig.yaml
@@ -126,6 +126,9 @@ controlPlane:
         controllerManager:
           extraArgs:
             bind-address: 0.0.0.0
+            # Force-delete terminal pods (Failed/Succeeded) once the
+            # cluster-wide count exceeds this; default is 12500 (= never).
+            terminated-pod-gc-threshold: "100"
         scheduler:
           extraArgs:
             bind-address: 0.0.0.0


### PR DESCRIPTION
kube-controller-manager defaults --terminated-pod-gc-threshold to 12500, effectively disabling podgc. A node/kubelet event left 59 orphaned cilium-operator pods (phase=Failed, ContainerStatusUnknown) that nothing sweeps. Set threshold to 100 so terminal pods are force-deleted once cluster-wide count exceeds it.
