### PR TITLE
chore(renovate): migrate config to home-operations/renovate-presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,31 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>home-operations/renovate-presets#6.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0",
+    ":timezone(America/Chicago)"
   ],
   "pinDigests": true,
-  "flux": {
-    "managerFilePatterns": [
-      "/(^|/)kubernetes/.+\\.ya?ml$/"
-    ]
-  },
-  "kubernetes": {
-    "managerFilePatterns": [
-      "/(^|/)kubernetes/.+\\.ya?ml$/"
-    ]
-  },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)kubernetes/.+\\.ya?ml$/",
-        "/(^|/)talos/.+\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s+version: (?<currentValue>\\S+)"
-      ]
-    }
-  ],
   "packageRules": [
     {
       "description": "Auto-merge patch updates silently",

--- a/docs/superpowers/specs/2026-08-07-renovate-presets-migration-design.md
+++ b/docs/superpowers/specs/2026-08-07-renovate-presets-migration-design.md
@@ -1,0 +1,89 @@
+# Renovate Config Migration to home-operations/renovate-presets
+
+**Date:** 2026-08-07
+**Status:** Approved
+**Scope:** `.github/renovate.json` + 8 exportarr/seerr `# renovate:` annotations in `kubernetes/downloads/*`
+
+## Problem
+
+`.github/renovate.json` hand-maintains a growing list of managers, custom
+managers, and file-pattern rules that overlap with the
+[`home-operations/renovate-presets`](https://github.com/home-operations/renovate-presets)
+bundle (v6.0.0, released 2026-08-07). The pre-#788 config produced semantic
+commit styles (`fix(helm): update chart …`) that the rewrite (#788) dropped in
+favor of generic `chore(deps): …` messages. Goal: standardize on the presets
+repo as the source of truth, keep only what presets deliberately don't ship
+(automerge policy, labels) local, and reduce maintenance.
+
+## Preset audit (v6.0.0)
+
+App presets under `apps/` are **opt-in** (6.0.0 breaking change: they were
+removed from `default.json`). Only `apps/talosFactory.json5` applies:
+
+| Preset | Applies? | Why |
+|---|---|---|
+| `apps/talosFactory` | ✅ | `talos/whoverse/clusterconfig/*.yaml` contain `factory.talos.dev/…/installer:…:v1.13.5` images, currently untracked |
+| `apps/cnpg` | ❌ | No CNPG anywhere; memos uses an external postgres |
+| `apps/grafanaDashboards` | ❌ | Dashboards are embedded `spec.json` in GrafanaDashboard CRs — no `grafanaCom`/grafana.com URL refs |
+| `apps/llamacpp`, `apps/phanpy`, `apps/searxng` | ❌ | None of these apps run here |
+
+The generic bundle (`default.json`) is extended wholesale: base config,
+manager file patterns, annotated + oci managers, all overrides (mise, helmfile,
+changelogs), and both policies (semanticCommits, zer0ver).
+
+## Solution
+
+Replace the hand-rolled managers/customManagers with preset extends; keep
+automerge + label rules local (presets ship no automerge policy):
+
+```jsonc
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>home-operations/renovate-presets#6.0.0",                          // generic bundle
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0", // opt-in: Talos
+    ":timezone(America/Chicago)"                                             // TZ for scheduling
+  ],
+  "pinDigests": true,   // top-level, after extends: overrides the github-actions digest helper
+  "packageRules": [ /* automerge policy + labels, unchanged */ ]
+}
+```
+
+Preset upgrades arrive via Renovate's renovate-config self-update PRs
+(tag-pinned, so there is a review point per bump).
+
+### Accepted behavior deltas
+
+1. **Broad manager file patterns** — flux/kubernetes scan all `.ya?ml`. Talos
+   machine configs start being tracked: `kubelet` (covered by the existing
+   no-automerge guard) plus new `kube-apiserver` / `kube-proxy` /
+   `kube-scheduler` (`registry.k8s.io`, `:v1.36.2`). Watch for noise; add a
+   targeted disable rule only if it materializes.
+2. **`factory.talos.dev` installer images** tracked via the talosFactory
+   custom datasource (currently untracked).
+3. **Annotated manager** replaces the local `version:`-only customManager
+   (handles `tag:`/`=`/quotes/anchors). The 8 exportarr/seerr `# renovate:`
+   annotations become duplicate deps (the flux manager already tracks those
+   images) → **annotations deleted**.
+4. **Semantic commit style** restored: `fix(helm): update chart …`,
+   `fix(container): update image …`; majors become `feat(...)!:`.
+5. **zer0ver policy** — 0.x minors get `!` prefix + `major-` branch routing.
+   Existing `!/^0/` automerge guards remain compatible.
+6. **Dependency Dashboard** enabled ("Renovate Dashboard 🤖" issue).
+7. **`:disableRateLimiting`** — no hourly PR cap (matches heavy automerge).
+8. **mise / helmfile / changelog overrides** — mise.toml single-word tools,
+   bootstrap helmfile depNames, cloudflared changelog.
+9. **`helpers:pinGitHubActionDigestsToSemver`** cancelled out by local
+   `pinDigests: true` (extends merge before top-level config).
+
+## Validation
+
+- `npx renovate-config-validator` on the new config (extends resolve, schema)
+- `pre-commit run --all-files` (gitleaks + trufflehog)
+- `just flate-test` (annotation removals touch `kubernetes/`)
+
+## Rollout
+
+Merge to main → GitHub-hosted Renovate picks up the new config on next run.
+Expected first-run outcomes: new dep extraction on talos configs, semantic
+commit style on new PRs, dependency dashboard issue created.

--- a/kubernetes/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/downloads/prowlarr/app/helmrelease.yaml
@@ -85,7 +85,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - prowlarr

--- a/kubernetes/downloads/radarr-anime/app/helmrelease.yaml
+++ b/kubernetes/downloads/radarr-anime/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - radarr

--- a/kubernetes/downloads/radarr-hd/app/helmrelease.yaml
+++ b/kubernetes/downloads/radarr-hd/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - radarr

--- a/kubernetes/downloads/radarr-uhd/app/helmrelease.yaml
+++ b/kubernetes/downloads/radarr-uhd/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - radarr

--- a/kubernetes/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/downloads/sabnzbd/app/helmrelease.yaml
@@ -95,7 +95,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - sabnzbd

--- a/kubernetes/downloads/seerr/app/helmrelease.yaml
+++ b/kubernetes/downloads/seerr/app/helmrelease.yaml
@@ -39,7 +39,6 @@ spec:
           seerr:
             image:
               repository: ghcr.io/seerr-team/seerr
-              # renovate: datasource=docker depName=seerr
               tag: v3.4.1@sha256:f4768de5f616248d723e05891f3345a1402123775d03bf0890dbfedc0831bda1
             env:
               TZ: "America/Chicago"

--- a/kubernetes/downloads/sonarr-anime/app/helmrelease.yaml
+++ b/kubernetes/downloads/sonarr-anime/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - sonarr

--- a/kubernetes/downloads/sonarr-hd/app/helmrelease.yaml
+++ b/kubernetes/downloads/sonarr-hd/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
           exportarr:
             image:
               repository: ghcr.io/onedr0p/exportarr
-              # renovate: datasource=docker depName=onedr0p/exportarr
               tag: v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520
             args:
               - sonarr


### PR DESCRIPTION
## Summary

Migrates `.github/renovate.json` from hand-maintained managers/policies to the [`home-operations/renovate-presets`](https://github.com/home-operations/renovate-presets) bundle (pinned **v6.0.0**).

```jsonc
"extends": [
  "github>home-operations/renovate-presets#6.0.0",                          // generic bundle
  "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0", // opt-in: Talos
  ":timezone(America/Chicago)"
]
```

## What changes

- **Removed local boilerplate** (~30 lines): flux/kubernetes `managerFilePatterns`, the `version:`-only customManager, `config:recommended` — replaced by the preset bundle
- **Automerge policy + labels: byte-identical to main** (presets deliberately ship no automerge policy) — verified programmatically
- **Dropped 8 redundant exportarr/seerr `# renovate:` annotations** — those images are already tracked by the flux manager; the preset's annotated manager would create duplicate deps on the same `tag:` lines
- **App preset audit** (design doc): only `apps/talosFactory` applies (we run `factory.talos.dev` installer images); cnpg/grafanaDashboards/llamacpp/phanpy/searxng don't exist in this repo
- **Preset upgrades** arrive as reviewable renovate-config self-update PRs (tag-pinned)

## Behavior deltas (accepted, see design doc)

| Delta | Effect |
|---|---|
| Broad manager file patterns | talos/ machine configs gain tracking: `factory.talos.dev` installer (new), `registry.k8s.io/kube-*` control-plane images (new PRs) |
| Semantic commit style | restored pre-#788 style: `fix(helm): update chart …`, `fix(container): update image …`; majors → `feat(...)!:` |
| zer0ver | 0.x minors get breaking `!` prefix + `major-` branch routing (existing `!/^0/` automerge guards remain compatible) |
| Dependency Dashboard | "Renovate Dashboard 🤖" issue enabled |
| `:disableRateLimiting` | no hourly PR cap |
| mise/helmfile/changelog overrides | mise.toml tools, bootstrap helmfile, cloudflared changelog |

## Validation

- `renovate-config-validator` ✅ (extends resolve, schema valid)
- `pre-commit run --all-files` ✅ (flate, gitleaks, trufflehog)
- `just flate-test` ✅ (186 passed)
- Design doc: `docs/superpowers/specs/2026-08-07-renovate-presets-migration-design.md`

> Note: unmerged `fix/renovate-0x-automerge-guard` / `fix/renovate-0x-patch-automerge` branches were **not** folded in — pre-1.0 automerge wording stays as main has it.