### PR TITLE
fix(renovate): automerge talos/k8s patch bumps; block core-infra minor automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -87,6 +87,23 @@
       "automergeType": "branch"
     },
     {
+      "description": "Core infrastructure: no minor automerge (breaking-change risk); patches/digests still flow via general rules",
+      "matchManagers": [
+        "flux"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "matchPackageNames": [
+        "/cilium/",
+        "/cert-manager/",
+        "/external-secrets/",
+        "/rook-ceph/",
+        "/envoyproxy/"
+      ],
+      "automerge": false
+    },
+    {
       "description": "Arr app images: auto-merge minor and digest (excluding pre-1.0)",
       "matchDatasources": [
         "docker"
@@ -103,16 +120,29 @@
       ]
     },
     {
-      "description": "Never auto-merge Talos or Kubernetes version bumps",
-      "matchDatasources": [
-        "docker"
-      ],
+      "description": "Talos & Kubernetes version bumps: keep major/minor/patch sequencing separate (patches automerge via the patch group; minors/majors stay reviewable)",
       "matchPackageNames": [
+        "siderolabs/talos",
         "ghcr.io/siderolabs/installer",
         "ghcr.io/siderolabs/kubelet"
       ],
       "separateMajorMinor": true,
       "separateMinorPatch": true
+    },
+    {
+      "description": "Talos & Kubernetes patch bumps: one automerged branch covering talconfig talosVersion + tuppr upgrade CRs",
+      "matchPackageNames": [
+        "siderolabs/talos",
+        "ghcr.io/siderolabs/installer",
+        "ghcr.io/siderolabs/kubelet"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "groupName": "Talos & Kubernetes patch bumps",
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "description": "Auto-merge npm minor updates (excluding pre-1.0)",
@@ -159,6 +189,7 @@
       ]
     },
     {
+      "description": "GitHub Actions: automerge all update types incl. major (intentional — reduces PR noise; revisit if a major ever breaks CI)",
       "matchManagers": [
         "github-actions"
       ],


### PR DESCRIPTION
## Summary

Three Renovate policy changes in `.github/renovate.json` (reviewed against the report on automerge behavior).

### 1. Talos & Kubernetes version bumps — sequencing + patch group
The "Never auto-merge Talos or Kubernetes version bumps" rule was a no-op: it never set `automerge: false`, so patches (and minors via the flux rule) already branch-automerged — `installer v1.13.8` and `kubelet v1.36.3` landed directly on main on Aug 5 and Jul 26.

Now the rule matches all three version-bump deps (`siderolabs/talos` talconfig `talosVersion` + tuppr `installer`/`kubelet` upgrade CRs):
- **Sequencing kept**: `separateMajorMinor` / `separateMinorPatch` — patches never get lumped into a branch with a reviewable minor/major.
- **Patch group added**: patch updates group into one automerged branch ("Talos & Kubernetes patch bumps") covering talconfig + tuppr CRs together; minors/majors stay reviewable PRs.
- Bonus: next Talos patch reconciles the current drift (talconfig `talosVersion: v1.13.5` vs tuppr `v1.13.8`).

### 2. Core-infra charts: no minor automerge
New rule (later in `packageRules`, so it overrides the general flux-minor automerge) blocks minor automerge for cilium, cert-manager, external-secrets, rook-ceph, envoy-gateway — breaking-change risk on cluster-critical path. Patches/digests still automerge; majors were already excluded.

### 3. github-actions rule — documented intent
Automerge of all update types incl. major is deliberate (PR-noise reduction); added a `description` so it's not re-flagged. No behavior change.

## Validation
- `renovate-config-validator` — config + extends resolve: passed
- `pre-commit run --all-files` (flate + gitleaks + trufflehog): passed
- `just flate-test`: 186 passed (2 pre-existing warnings, unchanged)

Expected effect on next Renovate run: the pending `renovate/siderolabs-talos-1.x` branch is superseded by the new patch group branch.