### PR TITLE
feat(towonel): add towonel hub deployment

### DIFF
--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - entertainment
   - default
   - downloads
+  - towonel
   - notifications
   - sync
   - agent-sandbox-system

--- a/kubernetes/towonel/hub/app/externalsecret.yaml
+++ b/kubernetes/towonel/hub/app/externalsecret.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: towonel-hub-secrets
+  namespace: towonel
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: towonel-hub-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: TOWONEL_IDENTITY_KEY
+      remoteRef:
+        key: towonel-hub
+        property: NODE_IDENTITY_KEY
+    - secretKey: TOWONEL_HUB_OPERATOR_API_KEY
+      remoteRef:
+        key: towonel-hub
+        property: OPERATOR_API_KEY
+    - secretKey: TOWONEL_HUB_KEK
+      remoteRef:
+        key: towonel-hub
+        property: HUB_KEK
+    - secretKey: TOWONEL_INVITE_HASH_KEY
+      remoteRef:
+        key: towonel-hub
+        property: INVITE_HASH_KEY
+    - secretKey: TOWONEL_HUB_LINK_PSK
+      remoteRef:
+        key: towonel-hub
+        property: HUB_LINK_PSK

--- a/kubernetes/towonel/hub/app/helmrelease.yaml
+++ b/kubernetes/towonel/hub/app/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: towonel-hub
+  namespace: towonel
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: towonel-node
+    namespace: towonel
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  values:
+    global:
+      fullnameOverride: towonel-hub
+    edge:
+      enabled: false
+    controllers:
+      main:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            env:
+              TOWONEL_DATA_DIR: /data
+              TOWONEL_HUB_PUBLIC_URL: https://hub.whoverse.dev
+              TOWONEL_HUB_TRUSTED_PROXIES: 10.244.0.0/16
+            envFrom:
+              - secretRef:
+                  name: towonel-hub-secrets
+    service:
+      link:
+        controller: main
+        type: LoadBalancer
+        loadBalancerClass: tailscale
+        annotations:
+          tailscale.com/hostname: towonel-hub-link
+          tailscale.com/proxy-group: ingress-proxies
+        ports:
+          hub-link:
+            port: 51444
+            targetPort: hub-link
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        dataSourceRef:
+          apiGroup: kopiur.home-operations.com
+          kind: Restore
+          name: towonel-hub
+        globalMounts:
+          - path: /data

--- a/kubernetes/towonel/hub/app/httproute.yaml
+++ b/kubernetes/towonel/hub/app/httproute.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hub-internal
+  namespace: towonel
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+  hostnames:
+    - hub.whoverse.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: towonel-hub-main
+          port: 8443

--- a/kubernetes/towonel/hub/app/kustomization.yaml
+++ b/kubernetes/towonel/hub/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ocirepository.yaml
+  - externalsecret.yaml
+  - httproute.yaml

--- a/kubernetes/towonel/hub/app/ocirepository.yaml
+++ b/kubernetes/towonel/hub/app/ocirepository.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: towonel-node
+  namespace: towonel
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "1.5.2"
+    digest: sha256:15721c6bc5ffae8f34e7603d02fcb6f74318fa0aed414db9929ef5467060c065
+  url: oci://codeberg.org/towonel/charts/towonel-node

--- a/kubernetes/towonel/hub/ks.yaml
+++ b/kubernetes/towonel/hub/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hub
+  namespace: towonel
+spec:
+  targetNamespace: towonel
+  components:
+    - ../../../components/kopiur/backup
+  interval: 30m
+  path: ./kubernetes/towonel/hub/app
+  postBuild:
+    substitute:
+      APP: towonel-hub
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+    namespace: flux-system
+  timeout: 10m
+  wait: true
+  prune: true

--- a/kubernetes/towonel/kustomization.yaml
+++ b/kubernetes/towonel/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ns.yaml
+  - hub/ks.yaml

--- a/kubernetes/towonel/ns.yaml
+++ b/kubernetes/towonel/ns.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: towonel
+  labels:
+    homelab.whoverse.dev/component: apps
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Hub-only towonel-node chart (v1.5.2) in a new towonel namespace:
- SQLite state on 1Gi RWO PVC, backed by kopiur hourly snapshots
- Hub API at https://hub.whoverse.dev via internal Envoy gateway
- hub/edge control link :51444 exposed as a Tailscale LB service
  (tailnet-only, for edge VMs)
- Hub keys/PSK synced from 1Password item towonel-hub
- Namespace pinned to restricted pod-security (credential-bearing app)
